### PR TITLE
SI-4597 implement loki related functions in the loki source code

### DIFF
--- a/src/loki.c
+++ b/src/loki.c
@@ -14,7 +14,7 @@
 
 // TODO maybe a thread that empties a buffer
 // static pthread_t loki_thread;
-int loki_running = 0;
+static int loki_running = 0;
 
 #define SERVER_PORT      3100
 #define BUFFER_SIZE      1024 * 1024
@@ -224,6 +224,19 @@ static void *read_pipe(void *arg) {
         }
     }
     return NULL;
+}
+
+/* Log commands to a Loki instance if enabled */
+void slash_on_execute_hook(const char *line) {
+	if(loki_running){
+		int ex_len = strlen(line);
+		char * dup = malloc(ex_len + 2);
+		strncpy(dup, line, ex_len);
+		dup[ex_len] = '\n';
+		dup[ex_len + 1] = '\0';
+		loki_add(dup, 1);
+		free(dup);
+	}
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/utsname.h>
@@ -79,6 +80,7 @@ int slash_prompt(struct slash * slash) {
 
 	}
 
+#ifdef PARAM_HAVE_COMMANDS
 	extern param_queue_t param_queue;
 	if (param_queue.type == PARAM_QUEUE_TYPE_GET) {
 
@@ -108,7 +110,7 @@ int slash_prompt(struct slash * slash) {
 		len += 2 + strlen(param_queue.name);
 
 	}
-
+#endif
 	/* End of breadcrumb */
 	fore = back;
 	printf(" \e[0m\e[0;38;5;%um \e[0m", fore);


### PR DESCRIPTION
- update "slash" submodule
- drive-by fix: allow compiling CSH without PARAM_HAVE_COMMANDS (I don't know why one would build without, but if one would, one couldn't without this fix)