### PR TITLE
Remove lib/yaml/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
   path = lib/slash
   url = https://github.com/spaceinventor/slash
   branch = master
-[submodule "lib/yaml"]
-	path = lib/yaml
-	url = https://github.com/yaml/libyaml.git

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,6 @@
 #include <slash/dflopt.h>
 
 #include <csp/csp.h>
-#include <csp/csp_yaml.h>
 #include <csp/csp_hooks.h>
 
 #include <curl/curl.h>


### PR DESCRIPTION
It seems that lib/yaml/ is no longer used as a dependency anywhere.
So it may be about time that we deleted it,
now that it has been replaced by .csh