### PR TITLE
Rename "struct slash" with typedef slash_t

### DIFF
--- a/src/csp_init_cmd.c
+++ b/src/csp_init_cmd.c
@@ -35,7 +35,7 @@ void * vmem_server_task(void * param) {
 	return NULL;
 }
 
-static int csp_init_cmd(struct slash *slash) {
+static int csp_init_cmd(slash_t *slash) {
 
     char * hostname = NULL;
     char * model = NULL;
@@ -111,7 +111,7 @@ static int csp_init_cmd(struct slash *slash) {
 slash_command_sub(csp, init, csp_init_cmd, NULL, "Initialize CSP");
 
 
-static int csp_ifadd_zmq_cmd(struct slash *slash) {
+static int csp_ifadd_zmq_cmd(slash_t *slash) {
 
     static int ifidx = 0;
 
@@ -216,7 +216,7 @@ static int csp_ifadd_zmq_cmd(struct slash *slash) {
 
 slash_command_subsub(csp, add, zmq, csp_ifadd_zmq_cmd, NULL, "Add a new ZMQ interface");
 
-static int csp_ifadd_kiss_cmd(struct slash *slash) {
+static int csp_ifadd_kiss_cmd(slash_t *slash) {
 
     static int ifidx = 0;
 
@@ -280,7 +280,7 @@ slash_command_subsub(csp, add, kiss, csp_ifadd_kiss_cmd, NULL, "Add a new KISS/U
 
 #if (CSP_HAVE_LIBSOCKETCAN)
 
-static int csp_ifadd_can_cmd(struct slash *slash) {
+static int csp_ifadd_can_cmd(slash_t *slash) {
 
     static int ifidx = 0;
 
@@ -365,7 +365,7 @@ static void eth_select_interface(const char ** device) {
     *device = selected;
 }
 
-static int csp_ifadd_eth_cmd(struct slash *slash) {
+static int csp_ifadd_eth_cmd(slash_t *slash) {
 
     static int ifidx = 0;
     char name[CSP_IFLIST_NAME_MAX + 1];
@@ -420,7 +420,7 @@ static int csp_ifadd_eth_cmd(struct slash *slash) {
 
 slash_command_subsub(csp, add, eth, csp_ifadd_eth_cmd, NULL, "Add a new Ethernet interface");
 
-static int csp_ifadd_udp_cmd(struct slash *slash) {
+static int csp_ifadd_udp_cmd(slash_t *slash) {
 
     static int ifidx = 0;
 
@@ -482,7 +482,7 @@ static int csp_ifadd_udp_cmd(struct slash *slash) {
 
 slash_command_subsub(csp, add, udp, csp_ifadd_udp_cmd, NULL, "Add a new UDP interface");
 
-static int csp_ifadd_tun_cmd(struct slash *slash) {
+static int csp_ifadd_tun_cmd(slash_t *slash) {
 
     static int ifidx = 0;
 
@@ -546,7 +546,7 @@ static int csp_ifadd_tun_cmd(struct slash *slash) {
 slash_command_subsub(csp, add, tun, csp_ifadd_tun_cmd, NULL, "Add a new TUN interface");
 
 #if CSP_USE_RTABLE
-static int csp_routeadd_cmd(struct slash *slash) {
+static int csp_routeadd_cmd(slash_t *slash) {
 
     char route[50];
 

--- a/src/csp_scan.c
+++ b/src/csp_scan.c
@@ -5,7 +5,7 @@
 #include <csp/csp.h>
 #include <csp/csp_cmp.h>
 
-static int csp_scan(struct slash *slash)
+static int csp_scan(slash_t *slash)
 {
     unsigned int begin = 0;
     unsigned int end = 0x3FFE;

--- a/src/hk_param_sniffer.c
+++ b/src/hk_param_sniffer.c
@@ -48,7 +48,7 @@ void hk_set_epoch(time_t epoch, uint16_t node) {
 	printf("Setting new hk node %u EPOCH to %lu\n", node, epoch);
 }
 
-static int hk_timeoffset(struct slash *slash) {
+static int hk_timeoffset(slash_t *slash) {
 
 	unsigned int node = slash_dfl_node;
     optparse_t * parser = optparse_new("hk timeoffset [epoch]", "Satellite epoch time in seconds relative to Jan 1th 1970");

--- a/src/known_hosts.c
+++ b/src/known_hosts.c
@@ -79,7 +79,7 @@ int known_hosts_get_node(const char * find_name) {
 }
 
 
-static int cmd_node_save(struct slash *slash)
+static int cmd_node_save(slash_t *slash)
 {
     
     FILE * out = stdout;
@@ -118,7 +118,7 @@ static int cmd_node_save(struct slash *slash)
 slash_command_sub(node, save, cmd_node_save, NULL, NULL);
 
 
-static int cmd_nodes(struct slash *slash)
+static int cmd_nodes(slash_t *slash)
 {
     /* Search for empty slot */
     for (int i = 0; i < MAX_HOSTS; i++) {
@@ -132,7 +132,7 @@ static int cmd_nodes(struct slash *slash)
 
 slash_command_sub(node, list, cmd_nodes, NULL, NULL);
 
-static int cmd_hosts_add(struct slash *slash)
+static int cmd_hosts_add(slash_t *slash)
 {
 
     int node = slash_dfl_node;

--- a/src/loki.c
+++ b/src/loki.c
@@ -240,7 +240,7 @@ void slash_on_execute_hook(const char *line) {
 }
 
 
-static int loki_start_cmd(struct slash * slash) {
+static int loki_start_cmd(slash_t * slash) {
 
     if (loki_running) return SLASH_SUCCESS;
 

--- a/src/main.c
+++ b/src/main.c
@@ -50,7 +50,7 @@ VMEM_DEFINE_FILE(cmd_store, "cmd_store", "cmd_store.vmem", 0x200*CMD_NUM_ELEMENT
 VMEM_DEFINE_FILE(sch_hash, "sch_hash", "sch_hash.vmem", 4*SCH_NUM_ELEMENTS);
 VMEM_DEFINE_FILE(sch_store, "sch_store", "sch_store.vmem", 0x100*SCH_NUM_ELEMENTS);
 
-int slash_prompt(struct slash * slash) {
+int slash_prompt(slash_t * slash) {
 
 	int len = 0;
 	int fore = 255;
@@ -158,7 +158,7 @@ void * onehz_task(void * param) {
 	return NULL;
 }
 
-static int cmd_sch_update(struct slash *slash) {
+static int cmd_sch_update(slash_t *slash) {
 
 	static pthread_t onehz_handle;
 	pthread_create(&onehz_handle, NULL, &onehz_task, NULL);
@@ -170,7 +170,7 @@ slash_command_sub(param_server, start, cmd_sch_update, "", "Update param server 
 
 /* Calling this variable "slash" somehow conflicts with __attribute__((section("slash"))) from "#define __slash_command()",
 	causing the linker error: symbol `slash' is already defined */
-static struct slash *slash2;
+static slash_t *slash2;
 #define slash slash2
 static void sigint_handler(int signum) {
 

--- a/src/nav.c
+++ b/src/nav.c
@@ -4,7 +4,7 @@
 #include <slash/slash.h>
 #include <slash/completer.h>
 
-static int slash_ls(struct slash *slash) {
+static int slash_ls(slash_t *slash) {
     
     char cwd[100];
     char *ignore = getcwd(cwd, 100);
@@ -32,7 +32,7 @@ static int slash_ls(struct slash *slash) {
 slash_command_completer(ls, slash_ls, slash_path_completer, "[path]", "list files");
 
 
-static int slash_cd(struct slash *slash) {
+static int slash_cd(slash_t *slash) {
 
     if (slash->argc != 2) {
         return SLASH_EUSAGE;
@@ -46,7 +46,7 @@ static int slash_cd(struct slash *slash) {
 
 slash_command_completer(cd, slash_cd, slash_path_completer, "", "change dir");
 
-static int slash_cat(struct slash *slash) {
+static int slash_cat(slash_t *slash) {
 
     if (slash->argc != 2) {
         return SLASH_EUSAGE;

--- a/src/prometheus.c
+++ b/src/prometheus.c
@@ -113,7 +113,7 @@ void prometheus_close(void) {
 }
 
 
-static int prometheus_start_cmd(struct slash *slash) {
+static int prometheus_start_cmd(slash_t *slash) {
 
     if(prometheus_started) return SLASH_SUCCESS;
 

--- a/src/resbuf_dump.c
+++ b/src/resbuf_dump.c
@@ -64,7 +64,7 @@ static vmem_list_t resbuf_get_base(int node, int timeout) {
 	return ret;
 }
 
-static int resbuf_dump_slash(struct slash *slash) {
+static int resbuf_dump_slash(slash_t *slash) {
 
     unsigned int node = slash_dfl_node;
 	char * filename = NULL;

--- a/src/slash_apm.c
+++ b/src/slash_apm.c
@@ -110,7 +110,7 @@ apm_entry_t * load_apm(const char * path) {
 
 }
 
-void initialize_apm(apm_entry_t * e, struct slash *slash) {
+void initialize_apm(apm_entry_t * e, slash_t *slash) {
 
     const int * apm_init_version_in_apm_ptr = dlsym(e->handle, "apm_init_version");
     if (apm_init_version_in_apm_ptr == NULL || apm_init_version != *apm_init_version_in_apm_ptr) {
@@ -243,7 +243,7 @@ void build_apm_list(lib_search_t* lib_search) {
  * Slash command
  */
 
-static int apm_load_cmd(struct slash *slash) {
+static int apm_load_cmd(slash_t *slash) {
 
     char path[WALKDIR_MAX_PATH_SIZE];    
     int search_bin_path = 0;
@@ -334,7 +334,7 @@ static int apm_load_cmd(struct slash *slash) {
 
 slash_command_sub(apm, load, apm_load_cmd, "", "Load an APM");
 
-static int apm_info_cmd(struct slash *slash) {
+static int apm_info_cmd(slash_t *slash) {
 
 	char * search_str = 0;
 

--- a/src/slash_csp.c
+++ b/src/slash_csp.c
@@ -35,7 +35,7 @@
 
 slash_command_group(csp, "Cubesat Space Protocol");
 
-static int slash_csp_info(struct slash *slash)
+static int slash_csp_info(slash_t *slash)
 {
 #if (CSP_HAVE_STDIO)
 #if (CSP_USE_RTABLE)
@@ -49,7 +49,7 @@ static int slash_csp_info(struct slash *slash)
 
 slash_command(info, slash_csp_info, NULL, "Show CSP info");
 
-static int slash_csp_ping(struct slash *slash)
+static int slash_csp_ping(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -88,7 +88,7 @@ static int slash_csp_ping(struct slash *slash)
 
 slash_command(ping, slash_csp_ping, "[node]", "Ping a system");
 
-static int slash_csp_reboot(struct slash *slash)
+static int slash_csp_reboot(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -116,7 +116,7 @@ static int slash_csp_reboot(struct slash *slash)
 
 slash_command(reboot, slash_csp_reboot, "[node]", "Reboot a node");
 
-static int slash_csp_shutdown(struct slash *slash)
+static int slash_csp_shutdown(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -144,7 +144,7 @@ static int slash_csp_shutdown(struct slash *slash)
 
 slash_command(shutdown, slash_csp_shutdown, "[node]", "Shutdown a node");
 
-static int slash_csp_buffree(struct slash *slash)
+static int slash_csp_buffree(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -174,7 +174,7 @@ static int slash_csp_buffree(struct slash *slash)
 
 slash_command(buffree, slash_csp_buffree, "[node]", "");
 
-static int slash_csp_uptime(struct slash *slash)
+static int slash_csp_uptime(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -204,7 +204,7 @@ static int slash_csp_uptime(struct slash *slash)
 
 slash_command(uptime, slash_csp_uptime, "[node]", "");
 
-static int slash_csp_cmp_ident(struct slash *slash)
+static int slash_csp_cmp_ident(slash_t *slash)
 {
 	
 	
@@ -269,7 +269,7 @@ static int slash_csp_cmp_ident(struct slash *slash)
 slash_command(ident, slash_csp_cmp_ident, "[node]", "Ident");
 
 
-static int slash_csp_cmp_ifstat(struct slash *slash)
+static int slash_csp_cmp_ifstat(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -337,7 +337,7 @@ static int slash_csp_cmp_ifstat(struct slash *slash)
 
 slash_command(ifstat, slash_csp_cmp_ifstat, "<node> <interface> [timeout]", "Ident");
 
-static int slash_csp_cmp_peek(struct slash *slash)
+static int slash_csp_cmp_peek(slash_t *slash)
 {
 
 	unsigned int node = slash_dfl_node;
@@ -404,7 +404,7 @@ static int slash_csp_cmp_peek(struct slash *slash)
 
 slash_command(peek, slash_csp_cmp_peek, "<address> <len>", "Peek");
 
-static int slash_csp_cmp_poke(struct slash *slash)
+static int slash_csp_cmp_poke(slash_t *slash)
 {
 	
 	unsigned int node = slash_dfl_node;
@@ -469,7 +469,7 @@ static int slash_csp_cmp_poke(struct slash *slash)
 
 slash_command(poke, slash_csp_cmp_poke, "<address> <data>", "Poke");
 
-static int slash_csp_cmp_time(struct slash *slash)
+static int slash_csp_cmp_time(slash_t *slash)
 {
 	unsigned int node = slash_dfl_node;
     unsigned int timeout = slash_dfl_timeout;

--- a/src/slash_eth.c
+++ b/src/slash_eth.c
@@ -45,7 +45,7 @@ slash_command_group(eth, "Ethernet");
 
 extern bool eth_debug;
 
-static int eth_debug_toggle(struct slash *slash)
+static int eth_debug_toggle(slash_t *slash)
 {
     eth_debug = !eth_debug;
     printf("Ethernet debugginbg %s\n", eth_debug ? "ON" : "OFF");
@@ -200,7 +200,7 @@ static void eth_list_interfaces()
     freeifaddrs(addresses);
 }
 
-static int eth_info(struct slash *slash)
+static int eth_info(slash_t *slash)
 {
     eth_list_interfaces();
     return SLASH_SUCCESS;

--- a/src/sleep_slash.c
+++ b/src/sleep_slash.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <slash/slash.h>
 
-static int cmd_sleep(struct slash *slash) {
+static int cmd_sleep(slash_t *slash) {
 
 	if (slash->argc != 2) {
         return SLASH_EUSAGE;

--- a/src/spaceboot_slash.c
+++ b/src/spaceboot_slash.c
@@ -76,7 +76,7 @@ static void reset_to_flash(int node, int flash, int times, int ms) {
 	ping(node);
 }
 
-static int slash_csp_switch(struct slash * slash) {
+static int slash_csp_switch(slash_t * slash) {
 
 
 	unsigned int node = slash_dfl_node;
@@ -282,7 +282,7 @@ static int upload_and_verify(int node, int address, char * data, int len) {
 	return SLASH_SUCCESS;
 }
 
-static int slash_csp_program(struct slash * slash) {
+static int slash_csp_program(slash_t * slash) {
 
 	unsigned int node = slash_dfl_node;
 	char * filename = NULL;
@@ -446,7 +446,7 @@ static int slash_csp_program(struct slash * slash) {
 slash_command(program, slash_csp_program, "<node> <slot> [filename]", "program");
 
 
-static int slash_sps(struct slash * slash) {
+static int slash_sps(slash_t * slash) {
 
 	unsigned int node = slash_dfl_node;
 	unsigned int reboot_delay = 1000;

--- a/src/stdbuf_client.c
+++ b/src/stdbuf_client.c
@@ -11,7 +11,7 @@
 static FILE * log_f = 0;
 static char log_name[100] = {0};
 
-static int stdbuf2_mon_slash(struct slash *slash) {
+static int stdbuf2_mon_slash(slash_t *slash) {
 
     unsigned int node = slash_dfl_node;
     unsigned int timeout = slash_dfl_timeout;

--- a/src/stdbuf_mon.c
+++ b/src/stdbuf_mon.c
@@ -82,7 +82,7 @@ static int stdbuf_get(uint16_t node, uint32_t base, int from, int to, int timeou
 
 }
 
-static int stdbuf_mon_slash(struct slash *slash) {
+static int stdbuf_mon_slash(slash_t *slash) {
 
 
     unsigned int node = slash_dfl_node;

--- a/src/victoria_metrics.c
+++ b/src/victoria_metrics.c
@@ -203,7 +203,7 @@ void vm_add_param(param_t * param) {
     }
 }
 
-static int vm_start_cmd(struct slash * slash) {
+static int vm_start_cmd(slash_t * slash) {
 
     if (vm_running) return SLASH_SUCCESS;
 
@@ -263,7 +263,7 @@ static int vm_start_cmd(struct slash * slash) {
 }
 slash_command_sub(vm, start, vm_start_cmd, "", "Start Victoria Metrics push thread");
 
-static int vm_stop_cmd(struct slash * slash) {
+static int vm_stop_cmd(slash_t * slash) {
 
     if (!vm_running) return SLASH_SUCCESS;
 

--- a/src/vts.c
+++ b/src/vts.c
@@ -69,7 +69,7 @@ void vts_add(double arr[4], uint16_t id, int count, uint64_t time_ms){
     }
 }
 
-static int vts_init(struct slash * slash) {
+static int vts_init(slash_t * slash) {
     char * server_ip = NULL;
     int port_num = 8888;
 


### PR DESCRIPTION
While debugging [3e8b7ce](https://github.com/spaceinventor/csh/commit/3e8b7ce64f103a229304a58b3dd0d72a28c2b122) I ended up trying out renaming the slash struct.
I decided to rename it with a typedef, so it would be more similar to param_t.

The amount of files changed is quite excessive, But as I had the changes working locally anyway, I figured I might as make a Pull Request, such that we can decide whether to align slash with param_t.