### PR TITLE
PLT-294 Added slash command to check used version of CSH

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,7 @@ csh_sources = [
 
 csh_sources += vcs_tag(input: files('src/version.c.in'), output: 'version.c', command: ['git', 'describe', '--always', '--dirty=+'])
 
-utils_lib_src = ['src/url_utils.c', 'src/environment.c']
+utils_lib_src = ['src/url_utils.c', 'src/environment.c', 'src/require_version.c']
 utils_lib_inc = include_directories('src')
 utils_lib = static_library('csh_utils', utils_lib_src, include_directories: utils_lib_inc)
 utils_lib_dep = declare_dependency(include_directories: utils_lib_inc, link_with : utils_lib)

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,7 @@ csh_sources = [
     'src/loki.c',
     'src/slash_env_var_cmds.c', 
     'src/slash_run_environment.c', 
+    'src/require_version.c', 
 ]
 
 csh_sources += vcs_tag(input: files('src/version.c.in'), output: 'version.c', command: ['git', 'describe', '--always', '--dirty=+'])

--- a/meson.build
+++ b/meson.build
@@ -70,6 +70,7 @@ csh_sources = [
     'src/slash_env_var_cmds.c', 
     'src/slash_run_environment.c', 
     'src/require_version.c', 
+    'src/require_version_cmd.c', 
 ]
 
 csh_sources += vcs_tag(input: files('src/version.c.in'), output: 'version.c', command: ['git', 'describe', '--always', '--dirty=+'])

--- a/src/require_version.c
+++ b/src/require_version.c
@@ -12,6 +12,7 @@ typedef struct {
 } version_t;
 
 
+// TODO: We should probably reuse the parsing logic from compare_version(), but then we need a separate function for parse operator.
 bool parse_version(const char *version_str, version_t *version) {
     if (!version_str || !version) return false;
 
@@ -184,13 +185,13 @@ static int slash_require_version_csh_cmd(struct slash *slash) {
 
     /* Check if version constraint is present */
 	if (++argi >= slash->argc) {
-        /* TODO: We could arguably have Fatal as default */
-		printf("missing error-level parameter\n");
+        /* TODO: We could arguably have Quit as default */
+		printf("missing error-action parameter\n");
         optparse_del(parser);
 		return SLASH_EINVAL;
 	}
-    char *error_level = slash->argv[argi];
-    *error_level = tolower(*error_level);  // Convert first letter to lower case
+    char *error_action = slash->argv[argi];
+    *error_action = tolower(*error_action);  // Convert first letter to lower case
 
     /* Check if user message is present */
 	if (++argi < slash->argc) {
@@ -199,14 +200,14 @@ static int slash_require_version_csh_cmd(struct slash *slash) {
 
     int err_ret = SLASH_EXIT;
 
-    if        (strcasestr("fatal", error_level)) {
+    if        (strcasestr("quit", error_action)) {
         err_ret = SLASH_EXIT;
-    } else if (strcasestr("error", error_level)) {
+    } else if (strcasestr("error", error_action)) {
         err_ret = SLASH_EBREAK;
-    } else if (strcasestr("warn", error_level)) {
+    } else if (strcasestr("warn", error_action)) {
         err_ret = SLASH_EINVAL;
     } else {
-        fprintf(stderr, "Unknown error type specfied: '%s'. Choices are: Fatal, Error, Warn\n", error_level);
+        fprintf(stderr, "Unknown error type specfied: '%s'. Choices are: Quit, Error, Warn\n", error_action);
         optparse_del(parser);
         return SLASH_EINVAL;
     }
@@ -240,13 +241,13 @@ static int slash_require_version_csh_cmd(struct slash *slash) {
     optparse_del(parser);
     return SLASH_SUCCESS;
 }
-slash_command_subsub(require, version, csh, slash_require_version_csh_cmd, "<version-constraint> <error-level> [error-message]",\
+slash_command_subsub(require, version, csh, slash_require_version_csh_cmd, "<version-constraint> <error-action> [error-message]",\
 "Checks whether CSH fulfills the specified version requirements.\n\n "\
-"A failed comparison may perform a varity of actions, based on the specified error level.\n "\
-"Possible error levels are:\n "\
-"- Fatal: Which will exit CSH,\n "\
+"A failed comparison may perform a varity of actions, based on the specified error action.\n "\
+"Possible error actions are:\n "\
+"- Quit: Which will exit CSH,\n "\
 "- Error: Which will break execution of a script,\n "\
 "- Warn: Which simply prints the specified message,\n "\
-"(Single letters may be used for error codes, e.g 'F' for Fatal).\n\n "\
+"(Single letters may be used for error codes, e.g 'F' for Quit).\n\n "\
 "Version constraint supports the typical comparisons: \"==\", \"!=\", \">=\", \"<=\", \">\" and \"<\".\n "\
 "For example: >=2.5-20");

--- a/src/require_version.c
+++ b/src/require_version.c
@@ -1,29 +1,23 @@
+
+#include "require_version.h"
+
 #include <ctype.h>
+#include <stdio.h>
 #include <string.h>
-
-#include <slash/slash.h>
-#include <slash/optparse.h>
-
-
-typedef struct {
-    int major;
-    int minor;
-    int patch;
-} version_t;
 
 
 // TODO: We should probably reuse the parsing logic from compare_version(), but then we need a separate function for parse operator.
-bool parse_version(const char *version_str, version_t *version) {
-    if (!version_str || !version) return false;
+bool parse_version(const char *version_str, version_t *version_out) {
+    if (!version_str || !version_out) return false;
 
     // Default the version fields to 0
-    version->major = version->minor = version->patch = 0;
+    version_out->major = version_out->minor = version_out->patch = 0;
 
     // Attempt to parse the version string
     int matched = sscanf(version_str, "%d.%d-%d", 
-                         &version->major, 
-                         &version->minor, 
-                         &version->patch);
+                         &version_out->major, 
+                         &version_out->minor, 
+                         &version_out->patch);
 
     if (matched >= 2) { // Parsed successfully in dash-separated format
         return true;
@@ -31,9 +25,9 @@ bool parse_version(const char *version_str, version_t *version) {
 
     // Try parsing the dot-separated format as fallback
     matched = sscanf(version_str, "%d.%d.%d", 
-                     &version->major, 
-                     &version->minor, 
-                     &version->patch);
+                     &version_out->major, 
+                     &version_out->minor, 
+                     &version_out->patch);
 
     return matched >= 2; // Parsed successfully in dot-separated format
 }
@@ -155,99 +149,3 @@ bool compare_version(const version_t *version, const char *constraint_dirty) {
 
     return true; // Unknown operator
 }
-
-/* TODO: Should we have either a command or argument for whether to allow dirty version of CSH?
-    It would be rather easy to check for the trailing '+' in the version string. */
-
-const struct slash_command slash_cmd_require_versioncsh;
-static int slash_require_version_csh_cmd(struct slash *slash) {
-
-    int verbose = false;
-    char *user_message = NULL;
-
-    optparse_t * parser = optparse_new_ex(slash_cmd_require_versioncsh.name, slash_cmd_require_versioncsh.args, slash_cmd_require_versioncsh.help);
-    optparse_add_set(parser, 'v', "verbose", 1, &verbose, "Verbose comparison");
-    optparse_add_help(parser);
-
-    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
-    if (argi < 0) {
-        optparse_del(parser);
-	    return SLASH_EINVAL;
-    }
-
-    /* Check if version constraint is present */
-	if (++argi >= slash->argc) {
-		printf("missing version constraint parameter\n");
-        optparse_del(parser);
-		return SLASH_EINVAL;
-	}
-    char *version_constraint = slash->argv[argi];
-
-    /* Check if version constraint is present */
-	if (++argi >= slash->argc) {
-        /* TODO: We could arguably have Quit as default */
-		printf("missing error-action parameter\n");
-        optparse_del(parser);
-		return SLASH_EINVAL;
-	}
-    char *error_action = slash->argv[argi];
-    *error_action = tolower(*error_action);  // Convert first letter to lower case
-
-    /* Check if user message is present */
-	if (++argi < slash->argc) {
-        user_message = slash->argv[argi];
-	}
-
-    int err_ret = SLASH_EXIT;
-
-    if        (strcasestr("quit", error_action)) {
-        err_ret = SLASH_EXIT;
-    } else if (strcasestr("error", error_action)) {
-        err_ret = SLASH_EBREAK;
-    } else if (strcasestr("warn", error_action)) {
-        err_ret = SLASH_EINVAL;
-    } else {
-        fprintf(stderr, "Unknown error type specfied: '%s'. Choices are: Quit, Error, Warn\n", error_action);
-        optparse_del(parser);
-        return SLASH_EINVAL;
-    }
-
-    extern const char *version_string;  // VCS tag set by meson.build using version.c.in
-
-    version_t csh_version;
-    if (false == parse_version(version_string, &csh_version)) {
-        fprintf(stderr, "CSH is tagged with a non semver complaint version '%s'\n", version_string);
-        optparse_del(parser);
-        /* err_ret may not be the best error code here,
-            but its our best guess at what the script author intended. */
-        return err_ret;
-    }
-
-    if (false == compare_version(&csh_version, version_constraint)) {
-        /* TODO: Should we print the error message in red, or let the user specify the color code? */
-        fprintf(stderr, "\033[31mVersion %s does not satisfy constraint %s", version_string, version_constraint);
-        if (user_message) {
-            fprintf(stderr, "\n%s", user_message);
-        }
-        fprintf(stderr, "\033[0m\n");
-        optparse_del(parser);
-        return err_ret;
-    }
-
-    if (verbose) {
-        printf("Version %s satisfies constraint %s\n", version_string, version_constraint);
-    }
-
-    optparse_del(parser);
-    return SLASH_SUCCESS;
-}
-slash_command_subsub(require, version, csh, slash_require_version_csh_cmd, "<version-constraint> <error-action> [error-message]",\
-"Checks whether CSH fulfills the specified version requirements.\n\n "\
-"A failed comparison may perform a varity of actions, based on the specified error action.\n "\
-"Possible error actions are:\n "\
-"- Quit: Which will exit CSH,\n "\
-"- Error: Which will break execution of a script,\n "\
-"- Warn: Which simply prints the specified message,\n "\
-"(Single letters may be used for error codes, e.g 'F' for Quit).\n\n "\
-"Version constraint supports the typical comparisons: \"==\", \"!=\", \">=\", \"<=\", \">\" and \"<\".\n "\
-"For example: >=2.5-20");

--- a/src/require_version.c
+++ b/src/require_version.c
@@ -1,0 +1,213 @@
+#include <ctype.h>
+#include <string.h>
+
+#include <slash/slash.h>
+#include <slash/optparse.h>
+
+
+typedef struct {
+    int major;
+    int minor;
+    int patch;
+} version_t;
+
+
+bool parse_version(const char *version_str, version_t *version) {
+    if (!version_str || !version) return false;
+
+    // Default the version fields to 0
+    version->major = version->minor = version->patch = 0;
+
+    // Attempt to parse the version string
+    int matched = sscanf(version_str, "%d.%d-%d", 
+                         &version->major, 
+                         &version->minor, 
+                         &version->patch);
+
+    if (matched >= 2) { // Parsed successfully in dash-separated format
+        return true;
+    } 
+
+    // Try parsing the dot-separated format as fallback
+    matched = sscanf(version_str, "%d.%d.%d", 
+                     &version->major, 
+                     &version->minor, 
+                     &version->patch);
+
+    return matched >= 2; // Parsed successfully in dot-separated format
+}
+
+
+static int compare_int(int a, int b) {
+    return (a > b) - (a < b); // Returns 1 if a > b, -1 if a < b, 0 if a == b
+}
+
+bool compare_version(const version_t *version, const char *constraint) {
+    if (!version || !constraint) {
+        return false;   
+    }
+
+    // Default values for constraint operator and version fields
+    char operator[3] = "=="; // Default to equality
+    version_t constraint_version = {0, 0, 0};
+
+    // Possible patterns to try
+    const char *patterns[] = {
+        "%2[<=>!]%d.%d.%d",  // Dot-separated with operator
+        "%2[<=>!]%d.%d-%d",  // Dash-separated with operator
+        "%d.%d.%d",          // Dot-separated without operator
+        "%d.%d-%d",          // Dash-separated without operator
+    };
+
+    int max_matched = 0;
+    for (size_t i = 0; i < sizeof(patterns) / sizeof(patterns[0]); ++i) {
+        char temp_operator[3] = {0}; // Temporary operator for this pattern
+        version_t temp_version = {0, 0, 0};
+
+        int matched = sscanf(constraint, patterns[i],
+                             temp_operator,
+                             &temp_version.major,
+                             &temp_version.minor,
+                             &temp_version.patch);
+
+        // Update the best match
+        if (matched <= max_matched) {
+            continue;  // This is not a better match
+        }
+
+        max_matched = matched;
+
+        // Save the best match results
+        if (matched >= 1 && strlen(temp_operator) > 0) {
+            strncpy(operator, temp_operator, sizeof(operator) - 1);
+        }
+        constraint_version = temp_version;
+    }
+
+    // Ensure at least major and minor versions were parsed
+    if (max_matched < 2) {
+        return false;
+    }
+
+    // Compare the parsed constraint version against the given version
+    int major_cmp = compare_int(version->major, constraint_version.major);
+    int minor_cmp = compare_int(version->minor, constraint_version.minor);
+    int patch_cmp = compare_int(version->patch, constraint_version.patch);
+
+    // Evaluate the operator
+    if (strcmp(operator, "==") == 0) {
+        return major_cmp == 0 && minor_cmp == 0 && patch_cmp == 0;
+    } else if (strcmp(operator, "!=") == 0) {
+        return major_cmp != 0 || minor_cmp != 0 || patch_cmp != 0;
+    } else if (strcmp(operator, ">=") == 0) {
+        return (major_cmp > 0) || (major_cmp == 0 && minor_cmp > 0) ||
+               (major_cmp == 0 && minor_cmp == 0 && patch_cmp >= 0);
+    } else if (strcmp(operator, "<=") == 0) {
+        return (major_cmp < 0) || (major_cmp == 0 && minor_cmp < 0) ||
+               (major_cmp == 0 && minor_cmp == 0 && patch_cmp <= 0);
+    } else if (strcmp(operator, ">") == 0) {
+        return (major_cmp > 0) || (major_cmp == 0 && minor_cmp > 0) ||
+               (major_cmp == 0 && minor_cmp == 0 && patch_cmp > 0);
+    } else if (strcmp(operator, "<") == 0) {
+        return (major_cmp < 0) || (major_cmp == 0 && minor_cmp < 0) ||
+               (major_cmp == 0 && minor_cmp == 0 && patch_cmp < 0);
+    }
+
+    return false; // Unknown operator
+}
+
+/* TODO: Should we have either a command or argument for whether to allow dirty version of CSH?
+    It would be rather easy to check for the trailing '+' in the version string. */
+
+const struct slash_command slash_cmd_require_versioncsh;
+static int slash_require_version_csh_cmd(struct slash *slash) {
+
+    int verbose = false;
+    char *user_message = NULL;
+
+    optparse_t * parser = optparse_new_ex(slash_cmd_require_versioncsh.name, slash_cmd_require_versioncsh.args, slash_cmd_require_versioncsh.help);
+    optparse_add_set(parser, 'v', "verbose", 1, &verbose, "Verbose comparison");
+    optparse_add_help(parser);
+
+    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+    if (argi < 0) {
+        optparse_del(parser);
+	    return SLASH_EINVAL;
+    }
+
+    /* Check if version constraint is present */
+	if (++argi >= slash->argc) {
+		printf("missing version constraint parameter\n");
+        optparse_del(parser);
+		return SLASH_EINVAL;
+	}
+    char *version_constraint = slash->argv[argi];
+
+    /* Check if version constraint is present */
+	if (++argi >= slash->argc) {
+        /* TODO: We could arguably have Fatal as default */
+		printf("missing error-level parameter\n");
+        optparse_del(parser);
+		return SLASH_EINVAL;
+	}
+    char *error_level = slash->argv[argi];
+    *error_level = tolower(*error_level);  // Convert first letter to lower case
+
+    /* Check if user message is present */
+	if (++argi < slash->argc) {
+        user_message = slash->argv[argi];
+	}
+
+    int err_ret = SLASH_EXIT;
+
+    if        (strcasestr("fatal", error_level)) {
+        err_ret = SLASH_EXIT;
+    } else if (strcasestr("error", error_level)) {
+        err_ret = SLASH_EBREAK;
+    } else if (strcasestr("warn", error_level)) {
+        err_ret = SLASH_EINVAL;
+    } else {
+        fprintf(stderr, "Unknown error type specfied: '%s'. Choices are: Fatal, Error, Warn\n", error_level);
+        optparse_del(parser);
+        return SLASH_EINVAL;
+    }
+
+    extern const char *version_string;  // VCS tag set by meson.build using version.c.in
+
+    version_t csh_version;
+    if (false == parse_version(version_string, &csh_version)) {
+        fprintf(stderr, "CSH is tagged with a non semver complaint version '%s'\n", version_string);
+        optparse_del(parser);
+        /* err_ret may not be the best error code here,
+            but its our best guess at what the script author intended. */
+        return err_ret;
+    }
+
+    if (false == compare_version(&csh_version, version_constraint)) {
+        /* TODO: Should we print the error message in red, or let the user specify the color code? */
+        fprintf(stderr, "\033[31mVersion %s does not satisfy constraint %s", version_string, version_constraint);
+        if (user_message) {
+            fprintf(stderr, "\n%s", user_message);
+        }
+        fprintf(stderr, "\033[0m\n");
+        optparse_del(parser);
+        return err_ret;
+    }
+
+    if (verbose) {
+        printf("Version %s satisfies constraint %s\n", version_string, version_constraint);
+    }
+
+    optparse_del(parser);
+    return SLASH_SUCCESS;
+}
+slash_command_subsub(require, version, csh, slash_require_version_csh_cmd, "<version-constraint> <error-level> [error-message]",\
+"Checks whether CSH fulfills the specified version requirements.\n\n "\
+"A failed comparison may perform a varity of actions, based on the specified error level.\n "\
+"Possible error levels are:\n "\
+"- Fatal: Which will exit CSH,\n "\
+"- Error: Which will break execution of a script,\n "\
+"- Warn: Which simply prints the specified message,\n "\
+"(Single letters may be used for error codes, e.g 'F' for Fatal).\n\n "\
+"Version constraint supports the typical comparisons: \"==\", \"!=\", \">=\", \"<=\", \">\" and \"<\".\n "\
+"For example: >=2.5-20");

--- a/src/require_version.c
+++ b/src/require_version.c
@@ -218,7 +218,7 @@ bool compare_version(const version_t *version, const char *constraint_dirty, boo
         return version_scaled < constraint_scaled;
     }
 
-    if (verbose) {
+    if (verbose) {  // Mostly for guarded by verbose flag for the sake of unit tests.
         fprintf(stderr, "\033[31mUnknown version constraint operator \"%s\"\033[0m\n", operator);
     }
     return false;  // Unknown operator

--- a/src/require_version.h
+++ b/src/require_version.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <ctype.h>
+#include <string.h>
+#include <stdbool.h>
+
+
+typedef struct {
+    int major;
+    int minor;
+    int patch;
+} version_t;
+
+
+bool parse_version(const char *version_str, version_t *version_out);
+
+bool compare_version(const version_t *version, const char *constraint);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/require_version.h
+++ b/src/require_version.h
@@ -19,7 +19,7 @@ typedef struct {
 
 bool parse_version(const char *version_str, version_t *version_out);
 
-bool compare_version(const version_t *version, const char *constraint);
+bool compare_version(const version_t *version, const char *constraint, bool verbose);
 
 #ifdef __cplusplus
 }

--- a/src/require_version.h
+++ b/src/require_version.h
@@ -17,7 +17,7 @@ typedef struct {
 } version_t;
 
 
-bool parse_version(const char *version_str, version_t *version_out);
+bool parse_version(const char *version_str, version_t *version_out, bool allow_suffix);
 
 bool compare_version(const version_t *version, const char *constraint, bool verbose);
 

--- a/src/require_version_cmd.c
+++ b/src/require_version_cmd.c
@@ -75,7 +75,7 @@ static int slash_require_version_csh_cmd(struct slash *slash) {
         return err_ret;
     }
 
-    if (false == compare_version(&csh_version, version_constraint)) {
+    if (false == compare_version(&csh_version, version_constraint, true)) {
         /* TODO: Should we print the error message in red, or let the user specify the color code? */
         fprintf(stderr, "\033[31mVersion %s does not satisfy constraint %s", version_string, version_constraint);
         if (user_message) {

--- a/src/require_version_cmd.c
+++ b/src/require_version_cmd.c
@@ -67,7 +67,7 @@ static int slash_require_version_csh_cmd(struct slash *slash) {
     extern const char *version_string;  // VCS tag set by meson.build using version.c.in
 
     version_t csh_version;
-    if (false == parse_version(version_string, &csh_version)) {
+    if (false == parse_version(version_string, &csh_version, true)) {
         fprintf(stderr, "CSH is tagged with a non semver complaint version '%s'\n", version_string);
         optparse_del(parser);
         /* err_ret may not be the best error code here,

--- a/src/require_version_cmd.c
+++ b/src/require_version_cmd.c
@@ -1,0 +1,105 @@
+
+#include "require_version.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#include <slash/slash.h>
+#include <slash/optparse.h>
+
+
+/* TODO: Should we have either a command or argument for whether to allow dirty version of CSH?
+    It would be rather easy to check for the trailing '+' in the version string. */
+
+const struct slash_command slash_cmd_require_versioncsh;
+static int slash_require_version_csh_cmd(struct slash *slash) {
+
+    int verbose = false;
+    char *user_message = NULL;
+
+    optparse_t * parser = optparse_new_ex(slash_cmd_require_versioncsh.name, slash_cmd_require_versioncsh.args, slash_cmd_require_versioncsh.help);
+    optparse_add_set(parser, 'v', "verbose", 1, &verbose, "Verbose comparison");
+    optparse_add_help(parser);
+
+    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+    if (argi < 0) {
+        optparse_del(parser);
+	    return SLASH_EINVAL;
+    }
+
+    /* Check if version constraint is present */
+	if (++argi >= slash->argc) {
+		printf("missing version constraint parameter\n");
+        optparse_del(parser);
+		return SLASH_EINVAL;
+	}
+    char *version_constraint = slash->argv[argi];
+
+    /* Check if version constraint is present */
+	if (++argi >= slash->argc) {
+        /* TODO: We could arguably have Quit as default */
+		printf("missing error-action parameter\n");
+        optparse_del(parser);
+		return SLASH_EINVAL;
+	}
+    char *error_action = slash->argv[argi];
+    *error_action = tolower(*error_action);  // Convert first letter to lower case
+
+    /* Check if user message is present */
+	if (++argi < slash->argc) {
+        user_message = slash->argv[argi];
+	}
+
+    int err_ret = SLASH_EXIT;
+
+    if        (strcasestr("quit", error_action)) {
+        err_ret = SLASH_EXIT;
+    } else if (strcasestr("error", error_action)) {
+        err_ret = SLASH_EBREAK;
+    } else if (strcasestr("warn", error_action)) {
+        err_ret = SLASH_EINVAL;
+    } else {
+        fprintf(stderr, "Unknown error type specfied: '%s'. Choices are: Quit, Error, Warn\n", error_action);
+        optparse_del(parser);
+        return SLASH_EINVAL;
+    }
+
+    extern const char *version_string;  // VCS tag set by meson.build using version.c.in
+
+    version_t csh_version;
+    if (false == parse_version(version_string, &csh_version)) {
+        fprintf(stderr, "CSH is tagged with a non semver complaint version '%s'\n", version_string);
+        optparse_del(parser);
+        /* err_ret may not be the best error code here,
+            but its our best guess at what the script author intended. */
+        return err_ret;
+    }
+
+    if (false == compare_version(&csh_version, version_constraint)) {
+        /* TODO: Should we print the error message in red, or let the user specify the color code? */
+        fprintf(stderr, "\033[31mVersion %s does not satisfy constraint %s", version_string, version_constraint);
+        if (user_message) {
+            fprintf(stderr, "\n%s", user_message);
+        }
+        fprintf(stderr, "\033[0m\n");
+        optparse_del(parser);
+        return err_ret;
+    }
+
+    if (verbose) {
+        printf("Version %s satisfies constraint %s\n", version_string, version_constraint);
+    }
+
+    optparse_del(parser);
+    return SLASH_SUCCESS;
+}
+slash_command_subsub(require, version, csh, slash_require_version_csh_cmd, "<version-constraint> <error-action> [error-message]",\
+"Checks whether CSH fulfills the specified version requirements.\n\n "\
+"A failed comparison may perform a varity of actions, based on the specified error action.\n "\
+"Possible error actions are:\n "\
+"- Quit: Which will exit CSH,\n "\
+"- Error: Which will break execution of a script,\n "\
+"- Warn: Which simply prints the specified message,\n "\
+"(Single letters may be used for error codes, e.g 'F' for Quit).\n\n "\
+"Version constraint supports the typical comparisons: \"==\", \"!=\", \">=\", \"<=\", \">\" and \"<\".\n "\
+"For example: >=2.5-20");

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -17,5 +17,15 @@ environment_tests = executable(
     dependencies: [gtest_dep, gtest_main_dep, utils_lib_dep],
     build_by_default: false
 )
+require_version_tests = executable(
+    'require_version_tests',
+    [
+        'require_version_tests.cpp',
+    ],
+    include_directories: ['../src'],
+    dependencies: [gtest_dep, gtest_main_dep, utils_lib_dep],
+    build_by_default: false
+)
 
 test('environment_tests', environment_tests)
+test('require_version_tests', require_version_tests)

--- a/tests/require_version_tests.cpp
+++ b/tests/require_version_tests.cpp
@@ -3,7 +3,7 @@
 
 TEST(require_version, require_version_tests) {
 
-    version_t version = {0};
+    
 
     #define STRINGIFY(x) str(x)
     #define str(x) #x
@@ -14,24 +14,68 @@ TEST(require_version, require_version_tests) {
     #define STR_MINOR STRINGIFY(MINOR)
     #define STR_PATCH STRINGIFY(PATCH)
     
-    ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "." STR_PATCH, &version));
+    {   /* Testing parse_version(), while also using it to generate the version_t for compare_version. */
 
-    /* Version parsed successfully, now check if it was also done correctly. */
-    ASSERT_EQ(version.major, MAJOR);
-    ASSERT_EQ(version.minor, MINOR);
-    ASSERT_EQ(version.patch, PATCH);
+        version_t version = {0};
 
-    /* We currently also allow dashes */
-    ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version));
+        /* Here are some things that are not valid version specifiers */
+        ASSERT_FALSE(parse_version("vv3.4.5", &version));
+        ASSERT_FALSE(parse_version("3..4.5", &version));
+        ASSERT_FALSE(parse_version("3.4.5.3", &version));
+        ASSERT_FALSE(parse_version("3.", &version));
+        ASSERT_FALSE(parse_version("3.d", &version));
+        ASSERT_FALSE(parse_version("3.v", &version));
+        ASSERT_FALSE(parse_version("2094967295.2094967295.2094967295", &version));  // Longer than VERSION_MAXLEN
 
-    /* So that should also be parsed correctly */
-    ASSERT_EQ(version.major, MAJOR);
-    ASSERT_EQ(version.minor, MINOR);
-    ASSERT_EQ(version.patch, PATCH);
+        /* It should be permissable to leave out certain parts of the version. */
+        ASSERT_TRUE(parse_version("v3", &version));
+        /* In such cases the remaining fields should be zeroed. */
+        ASSERT_EQ(version.major, 3);
+        ASSERT_EQ(version.minor, 0);
+        ASSERT_EQ(version.patch, 0);
+
+        ASSERT_TRUE(parse_version("4", &version));
+        ASSERT_EQ(version.major, 4);
+        ASSERT_EQ(version.minor, 0);
+        ASSERT_EQ(version.patch, 0);
+
+        ASSERT_TRUE(parse_version("5.3", &version));
+        ASSERT_EQ(version.major, 5);
+        ASSERT_EQ(version.minor, 3);
+        ASSERT_EQ(version.patch, 0);
+
+        ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "." STR_PATCH, &version));
+        /* Version parsed successfully, now check if it was also done correctly. */
+        ASSERT_EQ(version.major, MAJOR);
+        ASSERT_EQ(version.minor, MINOR);
+        ASSERT_EQ(version.patch, PATCH);
+
+        /* We currently also allow dashes */
+        ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version));
+        /* So that should also be parsed correctly */
+        ASSERT_EQ(version.major, MAJOR);
+        ASSERT_EQ(version.minor, MINOR);
+        ASSERT_EQ(version.patch, PATCH);
+
+        /* Check that it works with 'v' prefix as well */
+        ASSERT_TRUE(parse_version("v" STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version));
+        ASSERT_EQ(version.major, MAJOR);
+        ASSERT_EQ(version.minor, MINOR);
+        ASSERT_EQ(version.patch, PATCH);
+    
+    }
+
+    /* We could reuse the version from parse_version().
+        But explicitly recreating here allows us to make it const. */
+    const version_t version = {MAJOR, MINOR, PATCH};
 
     /* Let's also test our version constraints */
     ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR "." STR_PATCH));
     ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+
+    /* Operator should default to "==" */
+    ASSERT_TRUE(compare_version(&version, STR_MAJOR "." STR_MINOR "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
 
     ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR ".*"));
     ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-*"));
@@ -53,11 +97,13 @@ TEST(require_version, require_version_tests) {
     ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR ".*"));
     ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-*"));
 
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR "." STRINGIFY(PATCH-1)));
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-" STRINGIFY(PATCH-1)));
+    static_assert(PATCH-1 == 26);  /* TODO: How to stringify PATCH-1 ? */
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR "." "26"));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-" "26"));
 
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STRINGIFY(MINOR-1) "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STRINGIFY(MINOR-1) "-" STR_PATCH));
+    static_assert(MINOR-1 == 4);  /* TODO: How to stringify MINOR-1 ? */
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." "4" "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" "4" "-" STR_PATCH));
 
 
     ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
@@ -70,16 +116,19 @@ TEST(require_version, require_version_tests) {
     ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR ".*"));
     ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-*"));
 
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR "." STRINGIFY(PATCH+1)));
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-" STRINGIFY(PATCH+1)));
+    static_assert(PATCH+1 == 28);  /* TODO: How to stringify PATCH+1 ? */
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR "." "28"));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-" "28"));
 
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STRINGIFY(MINOR+1) "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STRINGIFY(MINOR+1) "-" STR_PATCH));
+    static_assert(MINOR+1 == 6);  /* TODO: How to stringify MINOR+1 ? */
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." "6" "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" "6" "-" STR_PATCH));
 
 
     ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
     ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "-*"));
 
-    ASSERT_TRUE(compare_version(&version, "!=" STRINGIFY(MAJOR+1) "." STR_MINOR "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, "!=" STRINGIFY(MAJOR+1) "-*"));
+    static_assert(MAJOR+1 == 4);  /* TODO: How to stringify MAJOR+1 ? */
+    ASSERT_TRUE(compare_version(&version, "!=" "4" "." STR_MINOR "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "!=" "4" "-*"));
 }

--- a/tests/require_version_tests.cpp
+++ b/tests/require_version_tests.cpp
@@ -19,49 +19,61 @@ TEST(require_version, require_version_tests) {
         version_t version = {0};
 
         /* Here are some things that are not valid version specifiers */
-        ASSERT_FALSE(parse_version("vv3.4.5", &version));
-        ASSERT_FALSE(parse_version("3..4.5", &version));
-        ASSERT_FALSE(parse_version("3.4.5.3", &version));
-        ASSERT_FALSE(parse_version("3.", &version));
-        ASSERT_FALSE(parse_version("3.d", &version));
-        ASSERT_FALSE(parse_version("3.v", &version));
-        ASSERT_FALSE(parse_version("2094967295.2094967295.2094967295", &version));  // Longer than VERSION_MAXLEN
+        ASSERT_FALSE(parse_version("vv3.4.5", &version, false));
+        ASSERT_FALSE(parse_version("3..4.5", &version, false));
+        ASSERT_FALSE(parse_version("3.4.5.3", &version, false));
+        ASSERT_FALSE(parse_version("3.", &version, false));
+        ASSERT_FALSE(parse_version("3.d", &version, false));
+        ASSERT_FALSE(parse_version("3.v", &version, false));
+        ASSERT_FALSE(parse_version("200000000000000000000000000000.200000000000000000000000000000.200000000000000000000000000000", &version, false));  // Long overflow
+        ASSERT_FALSE(parse_version("2147483648.2147483648.2147483648", &version, false));  // int32 overflow
 
         /* It should be permissable to leave out certain parts of the version. */
-        ASSERT_TRUE(parse_version("v3", &version));
+        ASSERT_TRUE(parse_version("v3", &version, false));
         /* In such cases the remaining fields should be zeroed. */
         ASSERT_EQ(version.major, 3);
         ASSERT_EQ(version.minor, 0);
         ASSERT_EQ(version.patch, 0);
 
-        ASSERT_TRUE(parse_version("4", &version));
+        ASSERT_TRUE(parse_version("4", &version, false));
         ASSERT_EQ(version.major, 4);
         ASSERT_EQ(version.minor, 0);
         ASSERT_EQ(version.patch, 0);
 
-        ASSERT_TRUE(parse_version("5.3", &version));
+        ASSERT_TRUE(parse_version("5.3", &version, false));
         ASSERT_EQ(version.major, 5);
         ASSERT_EQ(version.minor, 3);
         ASSERT_EQ(version.patch, 0);
 
-        ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "." STR_PATCH, &version));
+        ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "." STR_PATCH, &version, false));
         /* Version parsed successfully, now check if it was also done correctly. */
         ASSERT_EQ(version.major, MAJOR);
         ASSERT_EQ(version.minor, MINOR);
         ASSERT_EQ(version.patch, PATCH);
 
         /* We currently also allow dashes */
-        ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version));
+        ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version, false));
         /* So that should also be parsed correctly */
         ASSERT_EQ(version.major, MAJOR);
         ASSERT_EQ(version.minor, MINOR);
         ASSERT_EQ(version.patch, PATCH);
 
         /* Check that it works with 'v' prefix as well */
-        ASSERT_TRUE(parse_version("v" STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version));
+        ASSERT_TRUE(parse_version("v" STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version, false));
         ASSERT_EQ(version.major, MAJOR);
         ASSERT_EQ(version.minor, MINOR);
         ASSERT_EQ(version.patch, PATCH);
+
+        /* Test an actual CSH version */
+        ASSERT_TRUE(parse_version("2.5-36-g3b8a51f+", &version, true));
+        ASSERT_EQ(version.major, 2);
+        ASSERT_EQ(version.minor, 5);
+        ASSERT_EQ(version.patch, 36);
+
+        ASSERT_TRUE(parse_version("3.4.5.3", &version, true));
+        ASSERT_EQ(version.major, 3);
+        ASSERT_EQ(version.minor, 4);
+        ASSERT_EQ(version.patch, 5);
     
     }
 

--- a/tests/require_version_tests.cpp
+++ b/tests/require_version_tests.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+#include "require_version.h"
+
+TEST(require_version, require_version_tests) {
+
+    version_t version = {0};
+
+    #define STRINGIFY(x) str(x)
+    #define str(x) #x
+    #define MAJOR 3
+    #define MINOR 5
+    #define PATCH 27
+    #define STR_MAJOR STRINGIFY(MAJOR)
+    #define STR_MINOR STRINGIFY(MINOR)
+    #define STR_PATCH STRINGIFY(PATCH)
+    
+    ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "." STR_PATCH, &version));
+
+    /* Version parsed successfully, now check if it was also done correctly. */
+    ASSERT_EQ(version.major, MAJOR);
+    ASSERT_EQ(version.minor, MINOR);
+    ASSERT_EQ(version.patch, PATCH);
+
+    /* We currently also allow dashes */
+    ASSERT_TRUE(parse_version(STR_MAJOR "." STR_MINOR "-" STR_PATCH, &version));
+
+    /* So that should also be parsed correctly */
+    ASSERT_EQ(version.major, MAJOR);
+    ASSERT_EQ(version.minor, MINOR);
+    ASSERT_EQ(version.patch, PATCH);
+
+    /* Let's also test our version constraints */
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR ".*"));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-*"));
+
+    ASSERT_FALSE(compare_version(&version, "==" STRINGIFY(MAJOR-1) "." STR_MINOR ".*"));
+    ASSERT_FALSE(compare_version(&version, "==" STRINGIFY(MAJOR-1) "-" STR_MINOR "-*"));
+
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR ".*"));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-*"));
+
+
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "." STR_MINOR ".*"));
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "-" STR_MINOR "-*"));
+
+
+    ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR ".*"));
+    ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-*"));
+
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR "." STRINGIFY(PATCH-1)));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-" STRINGIFY(PATCH-1)));
+
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STRINGIFY(MINOR-1) "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STRINGIFY(MINOR-1) "-" STR_PATCH));
+
+
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR ".*"));
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "-" STR_MINOR "-*"));
+
+
+    ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR ".*"));
+    ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-*"));
+
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR "." STRINGIFY(PATCH+1)));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-" STRINGIFY(PATCH+1)));
+
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STRINGIFY(MINOR+1) "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STRINGIFY(MINOR+1) "-" STR_PATCH));
+
+
+    ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
+    ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "-*"));
+
+    ASSERT_TRUE(compare_version(&version, "!=" STRINGIFY(MAJOR+1) "." STR_MINOR "." STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "!=" STRINGIFY(MAJOR+1) "-*"));
+}

--- a/tests/require_version_tests.cpp
+++ b/tests/require_version_tests.cpp
@@ -70,65 +70,83 @@ TEST(require_version, require_version_tests) {
     const version_t version = {MAJOR, MINOR, PATCH};
 
     /* Let's also test our version constraints */
-    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-" STR_PATCH, false));
 
     /* Operator should default to "==" */
-    ASSERT_TRUE(compare_version(&version, STR_MAJOR "." STR_MINOR "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, STR_MAJOR "-" STR_MINOR "-" STR_PATCH, false));
 
-    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR ".*"));
-    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-*"));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "." STR_MINOR ".*", false));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-" STR_MINOR "-*", false));
 
-    ASSERT_FALSE(compare_version(&version, "==" STRINGIFY(MAJOR-1) "." STR_MINOR ".*"));
-    ASSERT_FALSE(compare_version(&version, "==" STRINGIFY(MAJOR-1) "-" STR_MINOR "-*"));
+    ASSERT_FALSE(compare_version(&version, "==" STRINGIFY(MAJOR-1) "." STR_MINOR ".*", false));
+    ASSERT_FALSE(compare_version(&version, "==" STRINGIFY(MAJOR-1) "-" STR_MINOR "-*", false));
 
-    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR ".*"));
-    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-*"));
-
-
-    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
-
-    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "." STR_MINOR ".*"));
-    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "-" STR_MINOR "-*"));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR ".*", false));
+    ASSERT_TRUE(compare_version(&version, "==" STR_MAJOR "-*", false));
 
 
-    ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR ".*"));
-    ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-*"));
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "-" STR_MINOR "-" STR_PATCH, false));
+
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "." STR_MINOR ".*", false));
+    ASSERT_TRUE(compare_version(&version, ">=" STR_MAJOR "-" STR_MINOR "-*", false));
+
+
+    ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR ".*", false));
+    ASSERT_FALSE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-*", false));
 
     static_assert(PATCH-1 == 26);  /* TODO: How to stringify PATCH-1 ? */
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR "." "26"));
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-" "26"));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." STR_MINOR "." "26", false));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" STR_MINOR "-" "26", false));
 
     static_assert(MINOR-1 == 4);  /* TODO: How to stringify MINOR-1 ? */
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." "4" "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" "4" "-" STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "." "4" "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, ">" STR_MAJOR "-" "4" "-" STR_PATCH, false));
 
 
-    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "-" STR_MINOR "-" STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "-" STR_MINOR "-" STR_PATCH, false));
 
-    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR ".*"));
-    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "-" STR_MINOR "-*"));
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "." STR_MINOR ".*", false));
+    ASSERT_TRUE(compare_version(&version, "<=" STR_MAJOR "-" STR_MINOR "-*", false));
 
 
-    ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR ".*"));
-    ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-*"));
+    ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR ".*", false));
+    ASSERT_FALSE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-*", false));
 
     static_assert(PATCH+1 == 28);  /* TODO: How to stringify PATCH+1 ? */
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR "." "28"));
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-" "28"));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." STR_MINOR "." "28", false));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" STR_MINOR "-" "28", false));
 
     static_assert(MINOR+1 == 6);  /* TODO: How to stringify MINOR+1 ? */
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." "6" "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" "6" "-" STR_PATCH));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "." "6" "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, "<" STR_MAJOR "-" "6" "-" STR_PATCH, false));
 
 
-    ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "." STR_MINOR "." STR_PATCH));
-    ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "-*"));
+    ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_FALSE(compare_version(&version, "!=" STR_MAJOR "-*", false));
 
     static_assert(MAJOR+1 == 4);  /* TODO: How to stringify MAJOR+1 ? */
-    ASSERT_TRUE(compare_version(&version, "!=" "4" "." STR_MINOR "." STR_PATCH));
-    ASSERT_TRUE(compare_version(&version, "!=" "4" "-*"));
+    ASSERT_TRUE(compare_version(&version, "!=" "4" "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_TRUE(compare_version(&version, "!=" "4" "-*", false));
+
+
+    /* Unknown operator test case */
+    ASSERT_FALSE(compare_version(&version, "<<" STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_FALSE(compare_version(&version, "<<" STR_MAJOR "-" STR_MINOR "-" STR_PATCH, false));
+
+    /* Too many operator characters */
+    ASSERT_FALSE(compare_version(&version, "====" STR_MAJOR "." STR_MINOR "." STR_PATCH, false));
+    ASSERT_FALSE(compare_version(&version, "====" STR_MAJOR "-" STR_MINOR "-" STR_PATCH, false));
+
+    /* Too many version parts */
+    ASSERT_FALSE(compare_version(&version, STR_MAJOR "." STR_MINOR "." STR_PATCH "." STR_PATCH, false));
+    ASSERT_FALSE(compare_version(&version, STR_MAJOR "-" STR_MINOR "-" STR_PATCH "-" STR_PATCH, false));
+
+    /* NOTE: Currently we have a maximum string length we will parse,
+        but this could be considered an implementation detail. */
+    ASSERT_FALSE(compare_version(&version, "2094967295.2094967295.2094967295", false));
+    ASSERT_FALSE(compare_version(&version, "2094967295-2094967295-2094967295", false));
 }


### PR DESCRIPTION
With the recently added feature of the \_\_FILE_DIR__ environment variable, it becomes apparent that CSH versions from before this commit will not work with scripts requiring the variable to be present.
This PR introduces a feature to help with such scenarios.

The new slash command: "require version csh" is useful in .csh scripts (init or not), where it can tell CSH to: exit, error or warn when a version constraint fails.

At the time of writing, the version constraint argument supports the typical comparisons: "==", "!=", ">=", "<=", ">" and "<".
But I have yet to add support for wildcard constraints, which would be useful for the patch version.

The name of the command is a bit clunky, as the intention is to also allow a command to check APM versions in the future.
Of course, if there are better suggestions for the name before merging, I would be happy to hear them.
The same can be said for the current error-level names: "fatal", "error" and "warn", where we may want to rename "fatal" to quit, so the all represent the resulting action.
I would like for the first letter of the error-level words to be different, as we currently allow single letters for short notation, of course this can also be debated.
