### PR TITLE
Use newly introduce CSH API, implement hostname tab-completion function (available in CSH API so that APMs can use it)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
   path = lib/slash
   url = https://github.com/spaceinventor/slash
   branch = master
+[submodule "lib/apm"]
+	path = lib/apm
+	url = https://github.com/spaceinventor/libapm_csh

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,8 @@ project('csh', ['c', 'cpp'], subproject_dir: 'lib', default_options: [
 
 add_global_arguments('-I../include', language: 'c')
 
+apm_api_dep = dependency('apm', fallback: ['apm', 'apm_csh_dep'], required: false).partial_dependency(includes: true)
+
 curl_dep = dependency('libcurl', required: false)
 if not curl_dep.found()
   error('libcurl not found! Please install libcurl4-openssl-dev or the appropriate package for your system.')
@@ -74,15 +76,15 @@ csh_sources = [
 	'src/vmem_client_slash.c',
 	'src/vmem_client_slash_ftp.c',
 	'src/param_scheduler_client.c',
-	'src/param_commands_client.c',
+	'src/param_commands_client.c'
 ]
 
 csh_sources += vcs_tag(input: files('src/version.c.in'), output: 'version.c', command: ['git', 'describe', '--always', '--dirty=+'])
 
 utils_lib_src = ['src/url_utils.c', 'src/environment.c', 'src/require_version.c', 'src/csh_defaults.c']
 utils_lib_inc = include_directories('src')
-utils_lib = static_library('csh_utils', utils_lib_src, include_directories: utils_lib_inc)
-utils_lib_dep = declare_dependency(include_directories: utils_lib_inc, link_with : utils_lib)
+utils_lib = static_library('csh_utils', utils_lib_src, include_directories: utils_lib_inc, dependencies: [apm_api_dep])
+utils_lib_dep = declare_dependency(include_directories: utils_lib_inc, link_with : utils_lib, dependencies: [apm_api_dep])
 
 subdir('tests')
 

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ csh_sources = [
     'src/victoria_metrics.c', 
     'src/loki.c',
     'src/slash_env_var_cmds.c', 
+    'src/slash_nodes_cmds.c', 
     'src/slash_run_environment.c', 
     'src/require_version.c', 
     'src/require_version_cmd.c', 
@@ -78,7 +79,7 @@ csh_sources = [
 
 csh_sources += vcs_tag(input: files('src/version.c.in'), output: 'version.c', command: ['git', 'describe', '--always', '--dirty=+'])
 
-utils_lib_src = ['src/url_utils.c', 'src/environment.c', 'src/require_version.c']
+utils_lib_src = ['src/url_utils.c', 'src/environment.c', 'src/require_version.c', 'src/csh_defaults.c']
 utils_lib_inc = include_directories('src')
 utils_lib = static_library('csh_utils', utils_lib_src, include_directories: utils_lib_inc)
 utils_lib_dep = declare_dependency(include_directories: utils_lib_inc, link_with : utils_lib)

--- a/src/csh_defaults.c
+++ b/src/csh_defaults.c
@@ -1,0 +1,2 @@
+unsigned int slash_dfl_node = 0;
+unsigned int slash_dfl_timeout = 1000;

--- a/src/csh_defaults.c
+++ b/src/csh_defaults.c
@@ -1,2 +1,10 @@
+#include <apm/csh_api.h>
+
 unsigned int slash_dfl_node = 0;
 unsigned int slash_dfl_timeout = 1000;
+unsigned int rdp_dfl_window = 3;
+unsigned int rdp_dfl_conn_timeout = 10000;
+unsigned int rdp_dfl_packet_timeout = 5000;
+unsigned int rdp_dfl_delayed_acks = 1;
+unsigned int rdp_dfl_ack_timeout = 2000;
+unsigned int rdp_dfl_ack_count = 2;

--- a/src/csh_internals.h
+++ b/src/csh_internals.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <slash/optparse.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void rdp_opt_add(optparse_t * parser);
+void rdp_opt_set();
+void rdp_opt_reset();
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/hk_param_sniffer.c
+++ b/src/hk_param_sniffer.c
@@ -15,8 +15,8 @@
 #include <csp/csp_crc32.h>
 
 #include <slash/slash.h>
-#include <slash/dflopt.h>
 #include <slash/optparse.h>
+#include <apm/csh_api.h>
 
 #include "param_sniffer.h"
 

--- a/src/known_hosts.c
+++ b/src/known_hosts.c
@@ -2,241 +2,240 @@
  * Naive, slow and simple storage of nodeid and hostname
  */
 
- #include "known_hosts.h"
+#include "known_hosts.h"
 
- #include <stdio.h>
- #include <stdlib.h>
- #include <string.h>
- #include <assert.h>
- #include <limits.h>
- #include <slash/slash.h>
- #include <slash/optparse.h>
- #include <slash/dflopt.h>
- 
- /*Both of these may be modified by APMs  */
- __attribute__((used, retain)) unsigned int known_host_storage_size = sizeof(host_t);
- SLIST_HEAD(known_host_s, host_s) known_hosts = {};
- 
- void host_name_completer(struct slash *slash, char * token) {
-         SLIST_HEAD(known_host_s, host_s) matching_hosts = {};
-     size_t token_l = strnlen(token, HOSTNAME_MAXLEN - 1);
-     int cur_prefix;
-     struct host_s *completion = NULL;
-     int len_to_compare_to = strlen(token);
-     int matches = 0;
-     int res;
-     for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
-         res = strncmp(element->name, token, token_l);
-         if (0 == res) {
-             matches++;
-             completion = malloc(sizeof(struct host_s));
-             completion->node = element->node;
-             strncpy(completion->name, element->name, HOSTNAME_MAXLEN - 1); 
-             SLIST_INSERT_HEAD(&matching_hosts, completion, next);
-         }
-     }
-     if(matches > 1) {
-         /* We only print all commands over 1 match here */
-         slash_printf(slash, "\n");
-     }
-     struct host_s *prev_completion = NULL;
-     struct host_s *cur_completion = NULL;
-     int prefix_len = INT_MAX;
- 
-     SLIST_FOREACH(cur_completion, &matching_hosts, next) {
-         /* Compute the length of prefix common to all completions */
-         if (prev_completion != 0) {
-             cur_prefix = slash_prefix_length(prev_completion->name, cur_completion->name);
-             if(cur_prefix < prefix_len) {
-                 prefix_len = cur_prefix;
-                 completion = cur_completion;
-             }
-         }
-         prev_completion = cur_completion;
-         if(matches > 1) {
-             slash_printf(slash, cur_completion->name);
-             slash_printf(slash, "\n");
-         }
-     }
-     if (matches == 1) {
-         *token = '\0';
-         strcat(slash->buffer, completion->name);
-         slash->cursor = slash->length = strlen(slash->buffer);
-     } else if(matches > 1) {
-         /* Fill the buffer with as much characters as possible:
-          * if what the user typed in doesn't end with a space, we might
-          * as well put all the common prefix in the buffer
-          */
-         if(slash->buffer[slash->length-1] != ' ' && len_to_compare_to < prefix_len) {
-             strncpy(&slash->buffer[slash->length] - len_to_compare_to, completion->name, prefix_len);
-             slash->cursor = slash->length = strlen(slash->buffer);
-         }
-     }
-     /* Free up the completion list we built up earlier */
-     while (!SLIST_EMPTY(&matching_hosts))
-     {
-         completion = SLIST_FIRST(&matching_hosts);
-         SLIST_REMOVE(&matching_hosts, completion, host_s, next);
-         free(completion);
-     }
- 
- }
- 
- void known_hosts_del(int host) {
- 
-     // SLIST_FOREACH(host_t host, &known_hosts, next) {
-     for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
-         if (element->node == host) {
-             SLIST_REMOVE(&known_hosts, element, host_s, next);  // Probably not the best time-complexity here, O(n)*2 perhaps?
-         }
-     }
- }
- 
- host_t * known_hosts_add(int addr, const char * new_name, bool override_existing) {
- 
-     if (addr == 0) {
-         return NULL;
-     }
- 
-     if (override_existing) {
-         known_hosts_del(addr);  // Ensure 'addr' is not in the list
-     } else {
-         
-         for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-             if (host->node == addr) {
-                 return host;  // This node is already in the linked list, and we are not allowed to override it.
-             }
-         }
-         // This node was not found in the list. Let's add it now.
-     }
- 
-     // TODO Kevin: Do we want to break the API, and let the caller supply "host"?
-     host_t * host = calloc(1, known_host_storage_size);
-     if (host == NULL) {
-         return NULL;  // No more memory
-     }
-     host->node = addr;
-     strncpy(host->name, new_name, HOSTNAME_MAXLEN-1);  // -1 to fit NULL byte
- 
-     SLIST_INSERT_HEAD(&known_hosts, host, next);
- 
-     return host;
- }
- 
- int known_hosts_get_name(int find_host, char * name, int buflen) {
- 
-     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-         if (host->node == find_host) {
-             strncpy(name, host->name, buflen);
-             return 1;
-         }
-     }
- 
-     return 0;
- 
- }
- 
- 
- int known_hosts_get_node(const char * find_name) {
- 
-     if (find_name == NULL)
-         return 0;
- 
-     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-         if (strncmp(find_name, host->name, HOSTNAME_MAXLEN) == 0) {
-             return host->node;
-         }
-     }
- 
-     return 0;
- 
- }
- 
-static void node_save(const char * filename) {
-     
-     FILE * out = stdout;
- 
-    if (filename) {
-        FILE * fd = fopen(filename, "w");
-     if (fd) {
-         out = fd;
-            printf("Writing to file %s\n", filename);
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <limits.h>
+#include <slash/slash.h>
+#include <slash/optparse.h>
+#include <slash/dflopt.h>
+
+/*Both of these may be modified by APMs  */
+__attribute__((used, retain)) unsigned int known_host_storage_size = sizeof(host_t);
+SLIST_HEAD(known_host_s, host_s) known_hosts = {};
+
+void host_name_completer(struct slash *slash, char * token) {
+        SLIST_HEAD(known_host_s, host_s) matching_hosts = {};
+    size_t token_l = strnlen(token, HOSTNAME_MAXLEN - 1);
+    int cur_prefix;
+    struct host_s *completion = NULL;
+    int len_to_compare_to = strlen(token);
+    int matches = 0;
+    int res;
+    for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
+        res = strncmp(element->name, token, token_l);
+        if (0 == res) {
+            matches++;
+            completion = malloc(sizeof(struct host_s));
+            completion->node = element->node;
+            strncpy(completion->name, element->name, HOSTNAME_MAXLEN - 1); 
+            SLIST_INSERT_HEAD(&matching_hosts, completion, next);
         }
-     }
- 
-     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-         assert(host->node != 0);  // Holdout from array-based known_hosts
-         if (host->node != 0) {
-             fprintf(out, "node add -n %d %s\n", host->node, host->name);
+    }
+    if(matches > 1) {
+        /* We only print all commands over 1 match here */
+        slash_printf(slash, "\n");
+    }
+    struct host_s *prev_completion = NULL;
+    struct host_s *cur_completion = NULL;
+    int prefix_len = INT_MAX;
+
+    SLIST_FOREACH(cur_completion, &matching_hosts, next) {
+        /* Compute the length of prefix common to all completions */
+        if (prev_completion != 0) {
+            cur_prefix = slash_prefix_length(prev_completion->name, cur_completion->name);
+            if(cur_prefix < prefix_len) {
+                prefix_len = cur_prefix;
+                completion = cur_completion;
+            }
+        }
+        prev_completion = cur_completion;
+        if(matches > 1) {
+            slash_printf(slash, cur_completion->name);
+            slash_printf(slash, "\n");
+        }
+    }
+    if (matches == 1) {
+        *token = '\0';
+        strcat(slash->buffer, completion->name);
+        slash->cursor = slash->length = strlen(slash->buffer);
+    } else if(matches > 1) {
+        /* Fill the buffer with as much characters as possible:
+        * if what the user typed in doesn't end with a space, we might
+        * as well put all the common prefix in the buffer
+        */
+        if(slash->buffer[slash->length-1] != ' ' && len_to_compare_to < prefix_len) {
+            strncpy(&slash->buffer[slash->length] - len_to_compare_to, completion->name, prefix_len);
+            slash->cursor = slash->length = strlen(slash->buffer);
+        }
+    }
+    /* Free up the completion list we built up earlier */
+    while (!SLIST_EMPTY(&matching_hosts))
+    {
+        completion = SLIST_FIRST(&matching_hosts);
+        SLIST_REMOVE(&matching_hosts, completion, host_s, next);
+        free(completion);
+    }
+
+}
+
+void known_hosts_del(int host) {
+
+    // SLIST_FOREACH(host_t host, &known_hosts, next) {
+    for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
+        if (element->node == host) {
+            SLIST_REMOVE(&known_hosts, element, host_s, next);  // Probably not the best time-complexity here, O(n)*2 perhaps?
+        }
+    }
+}
+
+host_t * known_hosts_add(int addr, const char * new_name, bool override_existing) {
+
+    if (addr == 0) {
+        return NULL;
+    }
+
+    if (override_existing) {
+        known_hosts_del(addr);  // Ensure 'addr' is not in the list
+    } else {
+        
+        for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+            if (host->node == addr) {
+                return host;  // This node is already in the linked list, and we are not allowed to override it.
+            }
+        }
+        // This node was not found in the list. Let's add it now.
+    }
+
+    // TODO Kevin: Do we want to break the API, and let the caller supply "host"?
+    host_t * host = calloc(1, known_host_storage_size);
+    if (host == NULL) {
+        return NULL;  // No more memory
+    }
+    host->node = addr;
+    strncpy(host->name, new_name, HOSTNAME_MAXLEN-1);  // -1 to fit NULL byte
+
+    SLIST_INSERT_HEAD(&known_hosts, host, next);
+
+    return host;
+}
+
+int known_hosts_get_name(int find_host, char * name, int buflen) {
+
+    for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+        if (host->node == find_host) {
+            strncpy(name, host->name, buflen);
+            return 1;
         }
     }
 
-    if (out != stdout) {
-        fflush(out);
-        fclose(out);
-     }
+    return 0;
+
+}
+
+
+int known_hosts_get_node(const char * find_name) {
+
+    if (find_name == NULL)
+        return 0;
+
+    for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+        if (strncmp(find_name, host->name, HOSTNAME_MAXLEN) == 0) {
+            return host->node;
+        }
+    }
+
+    return 0;
+
+}
+
+static void node_save(const char * filename) {
+    
+    FILE * out = stdout;
+
+if (filename) {
+    FILE * fd = fopen(filename, "w");
+    if (fd) {
+        out = fd;
+        printf("Writing to file %s\n", filename);
+    }
+    }
+
+    for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+        assert(host->node != 0);  // Holdout from array-based known_hosts
+        if (host->node != 0) {
+            fprintf(out, "node add -n %d %s\n", host->node, host->name);
+    }
+}
+
+if (out != stdout) {
+    fflush(out);
+    fclose(out);
+    }
 }
 
 const struct slash_command slash_cmd_node_save;
 static int cmd_node_save(struct slash *slash) {
-    char * filename = NULL;
+char * filename = NULL;
 
-    optparse_t * parser = optparse_new_ex(slash_cmd_node_save.name, slash_cmd_node_save.args, slash_cmd_node_save.help);
+optparse_t * parser = optparse_new_ex(slash_cmd_node_save.name, slash_cmd_node_save.args, slash_cmd_node_save.help);
+optparse_add_help(parser);
+optparse_add_string(parser, 'f', "filename", "PATH", &filename, "write to file");
+
+int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+if (argi < 0) {
+    optparse_del(parser);
+    return SLASH_EINVAL;
+}
+
+node_save(filename);
+
+optparse_del(parser);
+    return SLASH_SUCCESS;
+}
+slash_command_sub(node, save, cmd_node_save, "", "Save or print known nodes");
+slash_command_sub(node, list, cmd_node_save, "", "Save or print known nodes");  // Alias
+
+static int cmd_node_add(struct slash *slash)
+{
+
+    int node = slash_dfl_node;
+
+    optparse_t * parser = optparse_new("node add", "<name>");
     optparse_add_help(parser);
-    optparse_add_string(parser, 'f', "filename", "PATH", &filename, "write to file");
+    optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
     if (argi < 0) {
         optparse_del(parser);
-	    return SLASH_EINVAL;
+        return SLASH_EINVAL;
     }
 
-    node_save(filename);
+    if (node == 0) {
+        fprintf(stderr, "Refusing to add hostname for node 0");
+        optparse_del(parser);
+        return SLASH_EINVAL;
+    }
 
+    /* Check if name is present */
+    if (++argi >= slash->argc) {
+        printf("missing node hostname\n");
+        optparse_del(parser);
+        return SLASH_EINVAL;
+    }
+
+    char * name = slash->argv[argi];
+
+    if (known_hosts_add(node, name, true) == NULL) {
+        fprintf(stderr, "No more memory, failed to add host");
+        optparse_del(parser);
+        return SLASH_ENOMEM;  // We have already checked for node 0, so this can currently only be a memory error.
+    }
     optparse_del(parser);
-     return SLASH_SUCCESS;
- }
-slash_command_sub(node, save, cmd_node_save, "", "Save or print known nodes");
-slash_command_sub(node, list, cmd_node_save, "", "Save or print known nodes");  // Alias
- 
- static int cmd_node_add(struct slash *slash)
- {
- 
-     int node = slash_dfl_node;
- 
-     optparse_t * parser = optparse_new("node add", "<name>");
-     optparse_add_help(parser);
-     optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
- 
-     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
-     if (argi < 0) {
-         optparse_del(parser);
-         return SLASH_EINVAL;
-     }
- 
-     if (node == 0) {
-         fprintf(stderr, "Refusing to add hostname for node 0");
-         optparse_del(parser);
-         return SLASH_EINVAL;
-     }
- 
-     /* Check if name is present */
-     if (++argi >= slash->argc) {
-         printf("missing node hostname\n");
-         optparse_del(parser);
-         return SLASH_EINVAL;
-     }
- 
-     char * name = slash->argv[argi];
- 
-     if (known_hosts_add(node, name, true) == NULL) {
-         fprintf(stderr, "No more memory, failed to add host");
-         optparse_del(parser);
-         return SLASH_ENOMEM;  // We have already checked for node 0, so this can currently only be a memory error.
-     }
-     optparse_del(parser);
-     return SLASH_SUCCESS;
- }
- 
- slash_command_sub(node, add, cmd_node_add, NULL, NULL);
- 
+    return SLASH_SUCCESS;
+}
+
+slash_command_sub(node, add, cmd_node_add, NULL, NULL);

--- a/src/known_hosts.c
+++ b/src/known_hosts.c
@@ -2,114 +2,179 @@
  * Naive, slow and simple storage of nodeid and hostname
  */
 
-#include "known_hosts.h"
+ #include "known_hosts.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-
-#include <slash/slash.h>
-#include <slash/optparse.h>
-#include <slash/dflopt.h>
-
-/*Both of these may be modified by APMs  */
-__attribute__((used, retain)) unsigned int known_host_storage_size = sizeof(host_t);
-SLIST_HEAD(known_host_s, host_s) known_hosts = {};
-
-void known_hosts_del(int host) {
-
-    // SLIST_FOREACH(host_t host, &known_hosts, next) {
-    for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
-        if (element->node == host) {
-            SLIST_REMOVE(&known_hosts, element, host_s, next);  // Probably not the best time-complexity here, O(n)*2 perhaps?
-        }
-    }
-}
-
-host_t * known_hosts_add(int addr, const char * new_name, bool override_existing) {
-
-    if (addr == 0) {
-        return NULL;
-    }
-
-    if (override_existing) {
-        known_hosts_del(addr);  // Ensure 'addr' is not in the list
-    } else {
-        
-        for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-            if (host->node == addr) {
-                return host;  // This node is already in the linked list, and we are not allowed to override it.
-            }
-        }
-        // This node was not found in the list. Let's add it now.
-    }
-
-    // TODO Kevin: Do we want to break the API, and let the caller supply "host"?
-    host_t * host = calloc(1, known_host_storage_size);
-    if (host == NULL) {
-        return NULL;  // No more memory
-    }
-    host->node = addr;
-    strncpy(host->name, new_name, HOSTNAME_MAXLEN-1);  // -1 to fit NULL byte
-
-    SLIST_INSERT_HEAD(&known_hosts, host, next);
-
-    return host;
-}
-
-int known_hosts_get_name(int find_host, char * name, int buflen) {
-
-    for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-        if (host->node == find_host) {
-            strncpy(name, host->name, buflen);
-            return 1;
-        }
-    }
-
-    return 0;
-
-}
-
-
-int known_hosts_get_node(const char * find_name) {
-
-    if (find_name == NULL)
-        return 0;
-
-    for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-        if (strncmp(find_name, host->name, HOSTNAME_MAXLEN) == 0) {
-            return host->node;
-        }
-    }
-
-    return 0;
-
-}
-
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <assert.h>
+ #include <limits.h>
+ #include <slash/slash.h>
+ #include <slash/optparse.h>
+ #include <slash/dflopt.h>
+ 
+ /*Both of these may be modified by APMs  */
+ __attribute__((used, retain)) unsigned int known_host_storage_size = sizeof(host_t);
+ SLIST_HEAD(known_host_s, host_s) known_hosts = {};
+ 
+ void host_name_completer(struct slash *slash, char * token) {
+         SLIST_HEAD(known_host_s, host_s) matching_hosts = {};
+     size_t token_l = strnlen(token, HOSTNAME_MAXLEN - 1);
+     int cur_prefix;
+     struct host_s *completion = NULL;
+     int len_to_compare_to = strlen(token);
+     int matches = 0;
+     int res;
+     for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
+         res = strncmp(element->name, token, token_l);
+         if (0 == res) {
+             matches++;
+             completion = malloc(sizeof(struct host_s));
+             completion->node = element->node;
+             strncpy(completion->name, element->name, HOSTNAME_MAXLEN - 1); 
+             SLIST_INSERT_HEAD(&matching_hosts, completion, next);
+         }
+     }
+     if(matches > 1) {
+         /* We only print all commands over 1 match here */
+         slash_printf(slash, "\n");
+     }
+     struct host_s *prev_completion = NULL;
+     struct host_s *cur_completion = NULL;
+     int prefix_len = INT_MAX;
+ 
+     SLIST_FOREACH(cur_completion, &matching_hosts, next) {
+         /* Compute the length of prefix common to all completions */
+         if (prev_completion != 0) {
+             cur_prefix = slash_prefix_length(prev_completion->name, cur_completion->name);
+             if(cur_prefix < prefix_len) {
+                 prefix_len = cur_prefix;
+                 completion = cur_completion;
+             }
+         }
+         prev_completion = cur_completion;
+         if(matches > 1) {
+             slash_printf(slash, cur_completion->name);
+             slash_printf(slash, "\n");
+         }
+     }
+     if (matches == 1) {
+         *token = '\0';
+         strcat(slash->buffer, completion->name);
+         slash->cursor = slash->length = strlen(slash->buffer);
+     } else if(matches > 1) {
+         /* Fill the buffer with as much characters as possible:
+          * if what the user typed in doesn't end with a space, we might
+          * as well put all the common prefix in the buffer
+          */
+         if(slash->buffer[slash->length-1] != ' ' && len_to_compare_to < prefix_len) {
+             strncpy(&slash->buffer[slash->length] - len_to_compare_to, completion->name, prefix_len);
+             slash->cursor = slash->length = strlen(slash->buffer);
+         }
+     }
+     /* Free up the completion list we built up earlier */
+     while (!SLIST_EMPTY(&matching_hosts))
+     {
+         completion = SLIST_FIRST(&matching_hosts);
+         SLIST_REMOVE(&matching_hosts, completion, host_s, next);
+         free(completion);
+     }
+ 
+ }
+ 
+ void known_hosts_del(int host) {
+ 
+     // SLIST_FOREACH(host_t host, &known_hosts, next) {
+     for (host_t* element = SLIST_FIRST(&known_hosts); element != NULL; element = SLIST_NEXT(element, next)) {
+         if (element->node == host) {
+             SLIST_REMOVE(&known_hosts, element, host_s, next);  // Probably not the best time-complexity here, O(n)*2 perhaps?
+         }
+     }
+ }
+ 
+ host_t * known_hosts_add(int addr, const char * new_name, bool override_existing) {
+ 
+     if (addr == 0) {
+         return NULL;
+     }
+ 
+     if (override_existing) {
+         known_hosts_del(addr);  // Ensure 'addr' is not in the list
+     } else {
+         
+         for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+             if (host->node == addr) {
+                 return host;  // This node is already in the linked list, and we are not allowed to override it.
+             }
+         }
+         // This node was not found in the list. Let's add it now.
+     }
+ 
+     // TODO Kevin: Do we want to break the API, and let the caller supply "host"?
+     host_t * host = calloc(1, known_host_storage_size);
+     if (host == NULL) {
+         return NULL;  // No more memory
+     }
+     host->node = addr;
+     strncpy(host->name, new_name, HOSTNAME_MAXLEN-1);  // -1 to fit NULL byte
+ 
+     SLIST_INSERT_HEAD(&known_hosts, host, next);
+ 
+     return host;
+ }
+ 
+ int known_hosts_get_name(int find_host, char * name, int buflen) {
+ 
+     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+         if (host->node == find_host) {
+             strncpy(name, host->name, buflen);
+             return 1;
+         }
+     }
+ 
+     return 0;
+ 
+ }
+ 
+ 
+ int known_hosts_get_node(const char * find_name) {
+ 
+     if (find_name == NULL)
+         return 0;
+ 
+     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+         if (strncmp(find_name, host->name, HOSTNAME_MAXLEN) == 0) {
+             return host->node;
+         }
+     }
+ 
+     return 0;
+ 
+ }
+ 
 static void node_save(const char * filename) {
-
-    FILE * out = stdout;
-
+     
+     FILE * out = stdout;
+ 
     if (filename) {
         FILE * fd = fopen(filename, "w");
-        if (fd) {
-            out = fd;
+     if (fd) {
+         out = fd;
             printf("Writing to file %s\n", filename);
         }
-    }
-
-    for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
-        assert(host->node != 0);  // Holdout from array-based known_hosts
-        if (host->node != 0) {
-            fprintf(out, "node add -n %d %s\n", host->node, host->name);
+     }
+ 
+     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
+         assert(host->node != 0);  // Holdout from array-based known_hosts
+         if (host->node != 0) {
+             fprintf(out, "node add -n %d %s\n", host->node, host->name);
         }
     }
 
     if (out != stdout) {
         fflush(out);
         fclose(out);
-    }
+     }
 }
 
 const struct slash_command slash_cmd_node_save;
@@ -129,48 +194,49 @@ static int cmd_node_save(struct slash *slash) {
     node_save(filename);
 
     optparse_del(parser);
-    return SLASH_SUCCESS;
-}
+     return SLASH_SUCCESS;
+ }
 slash_command_sub(node, save, cmd_node_save, "", "Save or print known nodes");
 slash_command_sub(node, list, cmd_node_save, "", "Save or print known nodes");  // Alias
-
-static int cmd_hosts_add(struct slash *slash)
-{
-
-    int node = slash_dfl_node;
-
-    optparse_t * parser = optparse_new("hosts add", "<name>");
-    optparse_add_help(parser);
-    optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
-
-    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
-    if (argi < 0) {
-        optparse_del(parser);
-	    return SLASH_EINVAL;
-    }
-
-    if (node == 0) {
-        fprintf(stderr, "Refusing to add hostname for node 0");
-        optparse_del(parser);
-        return SLASH_EINVAL;
-    }
-
-	/* Check if name is present */
-	if (++argi >= slash->argc) {
-		printf("missing node hostname\n");
-        optparse_del(parser);
-		return SLASH_EINVAL;
-	}
-
-	char * name = slash->argv[argi];
-
-    if (known_hosts_add(node, name, true) == NULL) {
-        fprintf(stderr, "No more memory, failed to add host");
-        optparse_del(parser);
-        return SLASH_ENOMEM;  // We have already checked for node 0, so this can currently only be a memory error.
-    }
-    optparse_del(parser);
-    return SLASH_SUCCESS;
-}
-
-slash_command_sub(node, add, cmd_hosts_add, NULL, NULL);
+ 
+ static int cmd_node_add(struct slash *slash)
+ {
+ 
+     int node = slash_dfl_node;
+ 
+     optparse_t * parser = optparse_new("node add", "<name>");
+     optparse_add_help(parser);
+     optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+ 
+     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+     if (argi < 0) {
+         optparse_del(parser);
+         return SLASH_EINVAL;
+     }
+ 
+     if (node == 0) {
+         fprintf(stderr, "Refusing to add hostname for node 0");
+         optparse_del(parser);
+         return SLASH_EINVAL;
+     }
+ 
+     /* Check if name is present */
+     if (++argi >= slash->argc) {
+         printf("missing node hostname\n");
+         optparse_del(parser);
+         return SLASH_EINVAL;
+     }
+ 
+     char * name = slash->argv[argi];
+ 
+     if (known_hosts_add(node, name, true) == NULL) {
+         fprintf(stderr, "No more memory, failed to add host");
+         optparse_del(parser);
+         return SLASH_ENOMEM;  // We have already checked for node 0, so this can currently only be a memory error.
+     }
+     optparse_del(parser);
+     return SLASH_SUCCESS;
+ }
+ 
+ slash_command_sub(node, add, cmd_node_add, NULL, NULL);
+ 

--- a/src/known_hosts.c
+++ b/src/known_hosts.c
@@ -69,6 +69,7 @@ void host_name_completer(struct slash *slash, char * token) {
         */
         if(slash->buffer[slash->length-1] != ' ' && len_to_compare_to < prefix_len) {
             strncpy(&slash->buffer[slash->length] - len_to_compare_to, completion->name, prefix_len);
+            slash->buffer[slash->length - len_to_compare_to + prefix_len] = '\0';
             slash->cursor = slash->length = strlen(slash->buffer);
         }
     }

--- a/src/known_hosts.c
+++ b/src/known_hosts.c
@@ -11,7 +11,7 @@
 #include <limits.h>
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 
 /*Both of these may be modified by APMs  */
 __attribute__((used, retain)) unsigned int known_host_storage_size = sizeof(host_t);

--- a/src/known_hosts.c
+++ b/src/known_hosts.c
@@ -153,47 +153,45 @@ int known_hosts_get_node(const char * find_name) {
 }
 
 static void node_save(const char * filename) {
-    
     FILE * out = stdout;
-
-if (filename) {
-    FILE * fd = fopen(filename, "w");
-    if (fd) {
-        out = fd;
-        printf("Writing to file %s\n", filename);
-    }
+    if (filename) {
+        FILE * fd = fopen(filename, "w");
+        if (fd) {
+            out = fd;
+            printf("Writing to file %s\n", filename);
+        }
     }
 
     for (host_t* host = SLIST_FIRST(&known_hosts); host != NULL; host = SLIST_NEXT(host, next)) {
         assert(host->node != 0);  // Holdout from array-based known_hosts
         if (host->node != 0) {
             fprintf(out, "node add -n %d %s\n", host->node, host->name);
+        }
     }
-}
 
-if (out != stdout) {
-    fflush(out);
-    fclose(out);
+    if (out != stdout) {
+        fflush(out);
+        fclose(out);
     }
 }
 
 const struct slash_command slash_cmd_node_save;
 static int cmd_node_save(struct slash *slash) {
-char * filename = NULL;
+    char * filename = NULL;
 
-optparse_t * parser = optparse_new_ex(slash_cmd_node_save.name, slash_cmd_node_save.args, slash_cmd_node_save.help);
-optparse_add_help(parser);
-optparse_add_string(parser, 'f', "filename", "PATH", &filename, "write to file");
+    optparse_t * parser = optparse_new_ex(slash_cmd_node_save.name, slash_cmd_node_save.args, slash_cmd_node_save.help);
+    optparse_add_help(parser);
+    optparse_add_string(parser, 'f', "filename", "PATH", &filename, "write to file");
 
-int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
-if (argi < 0) {
+    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+    if (argi < 0) {
+        optparse_del(parser);
+        return SLASH_EINVAL;
+    }
+
+    node_save(filename);
+
     optparse_del(parser);
-    return SLASH_EINVAL;
-}
-
-node_save(filename);
-
-optparse_del(parser);
     return SLASH_SUCCESS;
 }
 slash_command_sub(node, save, cmd_node_save, "", "Save or print known nodes");

--- a/src/loki.c
+++ b/src/loki.c
@@ -9,7 +9,7 @@
 
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 
 #include <csp/csp.h>
 #include <csp/csp_types.h>

--- a/src/main.c
+++ b/src/main.c
@@ -8,8 +8,7 @@
 #include <signal.h>
 
 #include <slash/slash.h>
-#include <slash/dflopt.h>
-
+#include <apm/csh_api.h>
 #include <csp/csp.h>
 #include <csp/csp_hooks.h>
 

--- a/src/param_commands_slash.c
+++ b/src/param_commands_slash.c
@@ -11,7 +11,7 @@
 #include <inttypes.h>
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 
 #include <csp/csp.h>
 

--- a/src/param_list_slash.c
+++ b/src/param_list_slash.c
@@ -11,7 +11,7 @@
 #include <inttypes.h>
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 #include <vmem/vmem_client.h>
 
 #include <csp/csp_crc32.h>

--- a/src/param_scheduler_slash.c
+++ b/src/param_scheduler_slash.c
@@ -11,7 +11,8 @@
 #include <inttypes.h>
 #include <time.h>
 #include <slash/slash.h>
-#include <slash/dflopt.h>
+#include <slash/optparse.h>
+#include <apm/csh_api.h>
 
 #include <csp/csp.h>
 

--- a/src/param_slash.c
+++ b/src/param_slash.c
@@ -12,75 +12,75 @@
  #include <inttypes.h>
  #include <slash/slash.h>
  #include <slash/optparse.h>
- #include <slash/dflopt.h>
  #include <slash/completer.h>
- 
+ #include <apm/csh_api.h>
+
  #include <csp/csp.h>
  #include <csp/csp_hooks.h>
- 
+
  #include <param/param.h>
  #include <param/param_list.h>
  #include <param/param_client.h>
  #include <param/param_server.h>
  #include <param/param_queue.h>
  #include <param/param_string.h>
- 
+
  #include <param/param_wildcard.h>
  #include "time.h"
- 
+
  static char queue_buf[PARAM_SERVER_MTU];
  param_queue_t param_queue = { .buffer = queue_buf, .buffer_size = PARAM_SERVER_MTU, .type = PARAM_QUEUE_TYPE_EMPTY, .version = 2 };
- 
+
  int param_slash_parse_slice(char * token, int *start_index, int *end_index, int *slice_detected) {
 	 /**
 	  * Function to find offsets and check if slice delimitor is active.
 	  * @return Returns an array of three values. Defaults to INT_MIN if no value.
 	  * @return Last value is 1 if found.
 	 */
- 
+
 	 /* Search for the '@' symbol:
 	  * Call strtok twice in order to skip the stuff head of '@' */
- 
+
 	 char _slice_delimitor;
- 
+
 	 int first_scan = 0;
 	 int second_scan = 0;
- 
+
 	 if (token != NULL) {
 		 // Searches for the format [digit:digit] and [digit:].
 		 first_scan = sscanf(token, "%d%c%d", start_index, &_slice_delimitor, end_index);
- 
+
 		 if (first_scan <= 0) {
-			 // If the input was ":4" then no offsets will be set by the first sscanf, 
-			 // so we check for this and try again with another format to match.
-			 // second scan will never be 0, since a digit can still be loaded into %c.
-			 second_scan = sscanf(token, "%c%d", &_slice_delimitor, end_index);
+			// If the input was ":4" then no offsets will be set by the first sscanf,
+			// so we check for this and try again with another format to match.
+			// second scan will never be 0, since a digit can still be loaded into %c.
+			second_scan = sscanf(token, "%c%d", &_slice_delimitor, end_index);
 		 }
- 
+
 		 if (_slice_delimitor == ':') {
 			 *slice_detected = 1;
- 
+
 			 // Handle if second slice arg is invalid
 			 if (first_scan == 2 || second_scan == 1) {
 				 // First_scan == 2:
-				 // Token could either be a parsable value such as '2:' 
+				 // Token could either be a parsable value such as '2:'
 				 // or an invalid value such as '2:abc'.
-				 // '2:' Should pass. first_slice_arg is 2. second_slice_arg is NULL 
+				 // '2:' Should pass. first_slice_arg is 2. second_slice_arg is NULL
 				 // '2:abc' Should fail. first_slice_arg is 2. second_slice_arg is abc
- 
+
 				 // Second_scan == 1
 				 // Token could either be a parsable value such as ':'
 				 // or an invalid value such as ':a'
-				 // ':' Should pass. first_slice_arg is NULL. second_slice_arg is NULL 
+				 // ':' Should pass. first_slice_arg is NULL. second_slice_arg is NULL
 				 // ':a' Should fail. first_slice_arg is a. second_slice_arg is NULL
- 
-				 char * saveptr2;				
+
+				 char * saveptr2;
 				 char * first_slice_arg = strtok_r(token, ":", &saveptr2);
 				 char * second_slice_arg = strtok_r(NULL, ":", &saveptr2);
- 
+
 				 if (first_slice_arg && !second_slice_arg) {
 					 // values such as: '2:' and ':a'.
- 
+
 					 // Check if first slice arg is not a number
 					 // if it isnt a number, then value is invalid format such as: ':a'
 					 // If it is a number the value is valid format such as: '2:'
@@ -89,7 +89,7 @@
 						 fprintf(stderr, "Second slice arg is invalid.\nCan only parse integers as indexes to slice by.\n");
 						 return -1;
 					 }
- 
+
 				 } else if (first_slice_arg && second_slice_arg) {
 					 // Values such as: '2:abc'.
 					 // If both values are set and first_scan is 2 or second_scan is 1,
@@ -97,9 +97,9 @@
 					 fprintf(stderr, "Second slice arg is invalid.\nCan only parse integers as indexes to slice by.\n");
 					 return -1;
 				 }
- 
+
 			 }
- 
+
 		 } else if (second_scan > 0) {
 			 // If slice_delimitor is not ':' but second_scan still found something, then it must invalid input such as letters.
 			 fprintf(stderr, "Can only parse integers as indexes to slice by and ':' as delimitor.\n");
@@ -109,25 +109,25 @@
 			 fprintf(stderr, "Can only parse integers as indexes to slice by.\nSlice delimitor has to be ':'.\n");
 			 return -1;
 		 }
- 
+
 		 if (second_scan > 0 && _slice_delimitor == ']') {
 			 // This is an error, example: set test_array[] 4
 			 fprintf(stderr, "Cannot set empty array slice.\n");
 			 return -1;
 		 }
- 
+
 	 }
- 
+
 	 // 5 outcomes:
 	 // 1. [4]    ->    first_scan == 2 | second_scan == 0
-	 // 2. [4:]   ->    first_scan == 2 | second_scan == 0 
+	 // 2. [4:]   ->    first_scan == 2 | second_scan == 0
 	 // 3. [4:7]  ->    first_scan == 3 | second_scan == 0
 	  // 4. [:]    ->    first_scan == 0 | second_scan == 1
 	 // 5. [:7]   ->    first_scan == 0 | second_scan == 2
 	 // 1st and 2nd outcome we need to check on _slice_delimitor, if it is : then set slice_detected to 1
 	 return 0;
  }
- 
+
  static int param_parse_from_str(int node, char * arg, param_t **param) {
 	 char *endptr;
 	 int id = strtoul(arg, &endptr, 10);
@@ -137,42 +137,42 @@
 	 } else {
 		 *param = param_list_find_name(node, arg);
 	 }
- 
+
 	 if (*param == NULL) {
 		 return -1;
 	 }
- 
+
 	 return 0;
  }
- 
+
  // Find out if amount of values is equal to any of the parsed amounts.
  static int parse_slash_values(char ** args, int start_index, int expected_values_amount, ...) {
 	 va_list expected_values;
 	 va_start(expected_values, expected_values_amount);
- 
+
 	 int amount_of_values = 0;
- 
+
 	 for (int i = start_index; args[i] != NULL; i++) {
 		 amount_of_values++;
- 
+
 		 if (amount_of_values > 99) {
 			 break;
 		 }
- 
+
 	 }
- 
+
 	 for (int i = 0; i < expected_values_amount; i++) {
 		 if (amount_of_values == va_arg(expected_values, int)) {
 			 va_end(expected_values);
 			 return 0;
 		 }
- 
+
 	 }
- 
+
 	 va_end(expected_values);
 	 va_start(expected_values, expected_values_amount);
 	 fprintf(stderr, "Value amount error. Got %d values. Expected:", amount_of_values);
- 
+
 	 for (int i = 0; i < expected_values_amount - 1; i++) {
 		 int val = va_arg(expected_values, int);
 		 val = va_arg(expected_values, int);
@@ -180,34 +180,34 @@
 		 if (i < expected_values_amount - 2) {
 			 fprintf(stderr, ",");
 		 }
- 
+
 	 }
- 
+
 	 fprintf(stderr, ".\n");
 	 va_end(expected_values);
 	 return -1;
  }
- 
+
  static int param_get_offset_string(char * arg, char ** offsets) {
 	 char * saveptr;
 	 char * token;
- 
+
 	 strtok_r(arg, "[", &saveptr);
- 
+
 	 token = strtok_r(NULL, "[", &saveptr);
 	 if (token == NULL) {
 		 *offsets = NULL;
 		 return 0;
 	 }
- 
+
 	 // Check if close bracket exists as last element in token.
 	 // If not, then return an error.
 	 if(token[strlen(token)-1] != ']'){
 		 fprintf(stderr, "Missing close bracket on array slice.\n");
 		 return -1;
 	 }
- 
-	 // Check if slice input error, by checking if there are more characters after closing bracket. 
+
+	 // Check if slice input error, by checking if there are more characters after closing bracket.
 	 // Niche case, since closing bracket is detected as last element in the check above.
 	 // Case: set test_array_param[3]:5] | set test_array_param[3:]] 4
 	 int previous_token_length = strlen(token);
@@ -217,10 +217,10 @@
 		 return -1;
 	 }
 	 *offsets = token;
- 
+
 	 return 0;
  }
- 
+
  static int param_offsets_parse_from_str(char * arg, int array_size, int *offset_array, int *expected_value_amount) {
 	 if (arg == NULL) {
 		 for (int i = 0; i < array_size; i++) {
@@ -229,7 +229,7 @@
 		 *expected_value_amount = array_size;
 		 return 0;
 	 }
- 
+
 	 int current_index = 0;
 	 char *token = strtok(arg,",");
 	 while (token != NULL) {
@@ -237,17 +237,17 @@
 			 fprintf(stderr, "Amount of value indexes entered is greater than param array size.\n");
 			 return -1;
 		 }
- 
+
 		 char *semicolon_check = strchr(token, ':');
 		 if (semicolon_check != NULL) {
 			 int start_index = INT_MIN;
 			 int end_index = INT_MIN;
 			 int _slice_detected;
- 
+
 			 if (param_slash_parse_slice(token, &start_index, &end_index, &_slice_detected) < 0) {
 				 return -1;
 			 }
- 
+
 			 start_index = start_index != INT_MIN ? start_index : 0;
 			 end_index = end_index != INT_MIN ? end_index : array_size;
 			 if (start_index < 0) {
@@ -256,28 +256,28 @@
 				 if (start_index < 0) {
 					 return -1;
 				 }
- 
+
 			 }
- 
+
 			 // Same goes for the end index.
 			 if (end_index < 0) {
 				 end_index = array_size + end_index;
 				 if (end_index < 0) {
 					 return -1;
 				 }
- 
+
 			 }
- 
+
 			 if (start_index >= end_index) {
 				 fprintf(stderr, "start index is greater than end index in array slice.\n");
 				 return SLASH_EINVAL;
 			 }
- 
+
 			 if (end_index > array_size) {
 				 fprintf(stderr, "End index in slice is greater than param array size.\n");
 				 return SLASH_EINVAL;
 			 }
- 
+
 			 for (int i = start_index; i < end_index; i++) {
 				 if (current_index >= array_size) {
 					 fprintf(stderr, "Amount of value indexes entered is greater than param array size.\n");
@@ -285,42 +285,42 @@
 				 }
 				 offset_array[current_index++] = i;
 			 }
- 
+
 		 } else {
 			 int val = atoi(token);
- 
+
 			 if (val < 0) {
 				 val = val + array_size;
 			 }
- 
+
 			 offset_array[current_index++] = val;
 		 }
- 
+
 		 token = strtok(NULL, ",");
 	 }
 	 *expected_value_amount = current_index;
- 
+
 	 return 0;
  }
- 
+
  static int parse_param_offset_string(char * arg_in,  int node, param_t **param, char ** arg_out) {
 	 if (param_get_offset_string(arg_in, arg_out) < 0) {
 		 return -1;
 	 }
- 
+
 	 if (param_parse_from_str(node, arg_in, param) < 0) {
 		 if (*param == NULL) {
 			 fprintf(stderr, "%s not found.\n", arg_in);
 		 }
- 
+
 		 return -1;
 	 }
- 
+
 	 return 0;
  }
- 
+
  static int hasDuplicates(int arr[], int size) {
- 
+
 	 for (int i = 0; i < size; i++) {
 		 for (int j = i+1; j < size; j++) {
 			 if (arr[i] == arr[j]) {
@@ -328,18 +328,18 @@
 			 }
 		 }
 	 }
- 
-	 return 0; 
+
+	 return 0;
  }
- 
- 
+
+
  static void param_slash_parse(char * arg, int node, param_t **param, int *offset) {
- 
+
 	 /* Search for the '@' symbol:
 	  * Call strtok twice in order to skip the stuff head of '@' */
 	 char * saveptr;
 	 char * token;
- 
+
 	 /* Search for the '[' symbol: */
 	 strtok_r(arg, "[", &saveptr);
 	 token = strtok_r(NULL, "[", &saveptr);
@@ -347,49 +347,49 @@
 		 sscanf(token, "%d", offset);
 		 *token = '\0';
 	 }
- 
+
 	 char *endptr;
 	 int id = strtoul(arg, &endptr, 10);
- 
+
 	 if (*endptr == '\0') {
 		 *param = param_list_find_id(node, id);
 	 } else {
 		 *param = param_list_find_name(node, arg);
 	 }
- 
+
 	 return;
  }
- 
+
  static void param_completer(struct slash *slash, char * token) {
- 
+
 	 int matches = 0;
 	 size_t prefixlen = -1;
 	 param_t *prefix = NULL;
 	 char * orig_slash_buf = NULL;
- 
+
 	 int node = slash_dfl_node;
- 
+
 	 /* Build args */
 	 optparse_t * parser = optparse_new("", "");
 	 optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
 	 int argi = optparse_parse(parser, slash->argc, (const char **) slash->argv);
 	 optparse_del(parser);
- 
-	 /* 
+
+	 /*
 	 This is really important: the original slash->buffer MUST be saved and restored to its original
 	 value, otherwise, there will be trouble whenever it is freed (usually during csh clean up)
 	 */
 	 orig_slash_buf = slash->buffer;
- 
+
 	 /* The following code basically skips the cmd line all the way up to the last non option argument,
 	 a.k.a. the very thing we're trying to complete */
-	 if(argi != -1) {			
+	 if(argi != -1) {
 		 /* If options where given, skip past them */
 		  if (argi == slash->argc) {
 			 /* All arguments were cmd line options or their arguments, point past them*/
 			 slash->buffer = slash->buffer + strlen(slash->buffer);
 		 } else if (argi == 0) {
-			 /* No cmd line options, "token" already points to what is to be completed */	
+			 /* No cmd line options, "token" already points to what is to be completed */
 			 slash->buffer = token;
 		 } else {
 			 /* the remaining argument (at index slash->argc - 1) is leftovers after processing the options, a.k.a. the very thing we're trying to complete */
@@ -405,19 +405,21 @@
 	 }
 	 /* Finally, set "token" to the actual bit that needs completing */
 	 token = slash->buffer;
- 
+
 	 size_t tokenlen = strlen(token);
- 
+
 	 param_t * param;
 	 param_list_iterator i = { };
 	 bool found_completion = false;
 	 if (has_wildcard(token, strlen(token))) {
 		 // Only print parameters when globbing is involved.
 		 while ((param = param_list_iterate(&i)) != NULL) {
-			 if (strmatch(param->name, token, strlen(param->name), strlen(token))) {
-				 param_print(param, -1, NULL, 0, 2, 0);
-				 found_completion = true;
-			 }
+			if(node == *param->node) {
+				if (strmatch(param->name, token, strlen(param->name), strlen(token))) {
+					param_print(param, -1, NULL, 0, 2, 0);
+					found_completion = true;
+				}
+			}
 		 }
 		 slash_completer_revert_skip(slash, orig_slash_buf);
 		 if(!found_completion) {
@@ -425,19 +427,21 @@
 		 }
 		 return;
 	 }
- 
+
 	 while ((param = param_list_iterate(&i)) != NULL) {
- 
+		if(node != *param->node) {
+			continue;
+		}
 		 if (tokenlen > strlen(param->name))
 			 continue;
- 
+
 		 if (strncmp(token, param->name, slash_min(strlen(param->name), tokenlen)) == 0
 			 && *param->node == node) {
- 
+
 			 /* Count matches */
 			 matches++;
 			 found_completion = true;
- 
+
 			 /* Find common prefix */
 			 if (prefixlen == (size_t) -1) {
 				 prefix = param;
@@ -448,18 +452,18 @@
 				 if (new_prefixlen < prefixlen)
 					 prefixlen = new_prefixlen;
 			 }
- 
+
 			 /* Print newline on first match */
 			 if (matches == 1)
 				 slash_printf(slash, "\n");
- 
+
 			 /* Print param */
 			 param_print(param, -1, NULL, 0, 2, 0);
- 
+
 		 }
- 
+
 	 }
- 
+
 	 if (!matches) {
 		 printf("\nNo matching parameter found on node %d\n", node);
 		 slash_bell(slash);
@@ -468,90 +472,90 @@
 		 token[prefixlen] = 0;
 		 slash->cursor = slash->length = (token - slash->buffer) + prefixlen;
 	 }
- 
+
 	 slash_completer_revert_skip(slash, orig_slash_buf);
  }
- 
+
  static int cmd_get(struct slash *slash) {
- 
+
 	 int node = slash_dfl_node;
 	 int paramver = 2;
 	 int server = 0;
 	 int prio = CSP_PRIO_NORM;
- 
+
 	 optparse_t * parser = optparse_new("get", "<name>");
 	 optparse_add_help(parser);
 	 optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
 	 optparse_add_int(parser, 's', "server", "NUM", 0, &server, "server to get parameters from (default = node))");
 	 optparse_add_int(parser, 'v', "paramver", "NUM", 0, &paramver, "parameter system version (default = 2)");
 	 optparse_add_int(parser, 'p', "prio", "NUM", 0, &prio, "CSP priority (0 = CRITICAL, 1 = HIGH, 2 = NORM (default), 3 = LOW)");
- 
+
 	 int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
 	 if (argi < 0) {
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 /* Check if name is present */
 	 if (++argi >= slash->argc) {
 		 optparse_del(parser);
 		 printf("missing parameter name\n");
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 char * name = slash->argv[argi];
 	 int offset = -1;
 	 param_t * param = NULL;
- 
+
 	 if (++argi != slash->argc) {
 		 optparse_del(parser);
 		 printf("too many arguments to command\n");
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 /* Go through the list of parameters */
 	 param_list_iterator i = {};
 	 while ((param = param_list_iterate(&i)) != NULL) {
- 
+
 		 /* Name match (with wildcard) */
 		 if (strmatch(param->name, name, strlen(param->name), strlen(name)) == 0) {
 			 continue;
 		 }
- 
+
 		 /* Node match */
 		 if (*param->node != node) {
 			 continue;
 		 }
- 
+
 		 /* Local parameters are printed directly */
 		 if ((*param->node == 0) && (server == 0)) {
 			 param_print(param, -1, NULL, 0, 0, 0);
 			 continue;
 		 }
- 
+
 		 /* Select destination, host overrides parameter node */
 		 int dest = node;
 		 if (server > 0)
 			 dest = server;
- 
+
 		 if (param_pull_single(param, offset, prio, 1, dest, slash_dfl_timeout, paramver) < 0) {
 			 printf("No response\n");
 			 optparse_del(parser);
 			 return SLASH_EIO;
 		 }
- 
+
 	 }
- 
+
 	 optparse_del(parser);
 	 return SLASH_SUCCESS;
- 
+
  }
  static void param_get_cmd_completer(struct slash *slash, char * token) {
 	 param_completer(slash, token);
  }
- 
+
  slash_command_completer(get, cmd_get, param_get_cmd_completer, "<param>", "Get");
- 
+
  static int cmd_set(struct slash *slash) {
 	 int node = slash_dfl_node;
 	 int paramver = 2;
@@ -559,7 +563,7 @@
 	 int ack_with_pull = true;
 	 int force = false;
 	 int prio = CSP_PRIO_NORM;
- 
+
 	 optparse_t * parser = optparse_new("set", "<name>[offset] <value>");
 	 optparse_add_help(parser);
 	 optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
@@ -568,45 +572,45 @@
 	 optparse_add_set(parser, 'a', "no_ack_push", 0, &ack_with_pull, "Disable ack with param push queue");
 	 optparse_add_set(parser, 'f', "force", true, &force, "force setting readonly params");
 	 optparse_add_int(parser, 'p', "prio", "NUM", 0, &prio, "CSP priority (0 = CRITICAL, 1 = HIGH, 2 = NORM (default), 3 = LOW)");
- 
+
 	 int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
 	 if (argi < 0) {
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 /* Check if name is present */
 	 if (++argi >= slash->argc) {
 		 printf("missing parameter name\n");
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 char * name = slash->argv[argi];
- 
+
 	 param_t * param = NULL;
- 
+
 	 // offset array, amount of possible offsets should be equal to param->array_size.
 	 // Default set to INT_MIN to determine if they've been set or not, since an offset can be < 0.
 	 int * offset_array = NULL;
 	 char * offset_token = NULL;
- 
+
 	 // Get param name and offsets as a char array, if any offsets exist.
 	 if (parse_param_offset_string(name, node, &param, &offset_token) < 0) {
 		 fprintf(stderr, "Error when parsing offset string.\n");
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 if (param == NULL) {
 		 fprintf(stderr, "%s not found\n", name);
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 *param->timestamp = 0; /* Reset parameter timestamp before adding to queue, to avoid serializing it. */
 	 int expected_value_amount = 0;
- 
+
 	 // If param is of type data or string we only want to set on a single offset, that being -1.
 	 // Else we allocate memory for the offset array, fill it with INT_MIN, and parse the offset string to integers.
 	 // Lastly we set the expected_value_amount, this should match the amount of offsets put.
@@ -614,23 +618,30 @@
 		 offset_array = (int *)malloc(sizeof(int));
 		 offset_array[0] = -1;
 		 expected_value_amount = 1;
- 
+
 	 } else {
 		 offset_array = (int *)malloc(sizeof(int) * param->array_size);
- 
+
 		 for (int i = 0; i < param->array_size; i++) {
 			 offset_array[i] = INT_MIN;
 		 }
- 
+
 		 if (param_offsets_parse_from_str(offset_token, param->array_size, offset_array, &expected_value_amount) < 0) {
 			 free(offset_array);
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
-		 
- 
-		 offset_array = (int *)realloc(offset_array, sizeof(int)*expected_value_amount);
- 
+
+		 int *tmp = (int *)realloc(offset_array, sizeof(int)*expected_value_amount);
+		 if(tmp) {
+		 	offset_array = tmp;
+		 } else {
+			fprintf(stderr,"Couldn't realloc 'offset_array', bailing out.\n");
+			free(offset_array);
+			optparse_del(parser);
+			return SLASH_EINVAL;
+		 }
+
 		 if(hasDuplicates(offset_array, expected_value_amount) == 1) {
 			 // offset_array has duplicate offsets. This should give an error.
 			 fprintf(stderr,"Offset array contain duplicate offsets.\n");
@@ -638,11 +649,11 @@
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 	 }
- 
+
 	 offset_token = NULL;
- 
+
 	 if (param->array_size == 1) {
 		 if (expected_value_amount > 1) {
 			 fprintf(stderr, "Cannot do array and slicing operations on a non-array parameter.\n");
@@ -651,14 +662,14 @@
 			 return SLASH_EINVAL;
 		 }
 	 }
- 
+
 	 if (param->mask & PM_READONLY && !force) {
 		 printf("--force is required to set a readonly parameter\n");
 		 free(offset_array);
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 /* Check if Value is present */
 	 if (++argi >= slash->argc) {
 		 printf("missing parameter value\n");
@@ -666,7 +677,7 @@
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 // Parse expected amount of values
 	 // We expect an amount of values equal to the size of offset_array.
 	 // The size of offset_array can at most be equal to the param->array_size.
@@ -675,19 +686,19 @@
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 // Create a queue, so that we can set the param in a single packet.
 	 param_queue_t queue;
 	 char queue_buf[PARAM_SERVER_MTU];
 	 param_queue_init(&queue, queue_buf, PARAM_SERVER_MTU, 0, PARAM_QUEUE_TYPE_SET, 2);
- 
+
 	 // We should iterate until we find an ending bracket ']'. Therefore we use the 'should_break' flag.
 	 int should_break = 1;
 	 int iterations = 0;
 	 int single_value_flag = 0;
 	 for (int i = argi; should_break == 1; i++) {
 		 char valuebuf[128] __attribute__((aligned(16))) = { };
- 
+
 		 char *arg = slash->argv[i];
 		 if (!arg) {
 			 fprintf(stderr, "Missing closing bracket\n");
@@ -695,7 +706,7 @@
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 		 // Check if we can find a start bracket '['.
 		 // If we can, then we're dealing with a value array.
 		 if (strchr(arg, '[')) {
@@ -706,52 +717,52 @@
 				 optparse_del(parser);
 				 return SLASH_EINVAL;
 			 }
- 
+
 			 arg++;
 			 // A value array with a single element can also be passed.
 			 if (arg[strlen(arg)-1] == ']') {
 				 arg[strlen(arg)-1] = '\0';
 				 should_break = 0;
 			 }
- 
+
 		 } else if (arg[strlen(arg)-1] == ']') {
 			 // Check if we can find an ending brakcet ']'.
 			 // If we can, then we should stop looping after the current iteration.
 			 arg[strlen(arg)-1] = '\0';
 			 should_break = 0;
 		 } else if (iterations == 0) {
-			 // If no bracket was found and the current iteration is the first iteration, then we are dealing with a single value. 
+			 // If no bracket was found and the current iteration is the first iteration, then we are dealing with a single value.
 			 single_value_flag = 1;
 		 }
- 
-		 // Convert the valuebuf str to a value of the param type. 
+
+		 // Convert the valuebuf str to a value of the param type.
 		 if (param_str_to_value(param->type, arg, valuebuf) < 0) {
 			 fprintf(stderr, "invalid parameter value\n");
 			 free(offset_array);
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
- 
+
+
 		 // If we're dealing with a single value, we should loop the sliced array instead of the values.
 		 // Breaking afterwards, since this means we're done setting params.
 		 if (single_value_flag) {
 			 for (int j = 0; j < expected_value_amount; j++) {
 				 param_queue_add(&queue, param, offset_array[j], valuebuf);
 			 }
- 
+
 			 break;
 		 }
- 
+
 		 // If we're not dealing with a single value, we should look at iterations.
-		 // If iterations ever becomes greater than expected_value_amount, it means the amount of values are greater than the slice. 
+		 // If iterations ever becomes greater than expected_value_amount, it means the amount of values are greater than the slice.
 		 if (iterations > expected_value_amount) {
 			 fprintf(stderr, "Values array is longer than value indexes\n");
 			 free(offset_array);
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 		 // Add to the queue.
 		 if (param_queue_add(&queue, param, offset_array[iterations], valuebuf) < 0) {
 			 fprintf(stderr, "Param_queue_add failed\n");
@@ -759,10 +770,10 @@
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 		 iterations++;
- 
-		 // If we hit the end value by detecting ']', and start index and end index are not equal, 
+
+		 // If we hit the end value by detecting ']', and start index and end index are not equal,
 		 // then the slice length must be greater than the value array length.
 		 // This shouldnt be possible, so we throw an error.
 		 if (should_break == 0 && iterations != expected_value_amount) {
@@ -771,23 +782,23 @@
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 	 }
- 
+
 	 /* Local parameters are set directly */
 	 if (*param->node == 0) {
 		 param_queue_apply(&queue, 1, 0);
- 
+
 		 // if (offset < 0 && param->type != PARAM_TYPE_STRING && param->type != PARAM_TYPE_DATA) {
 		 // 	for (int i = 0; i < param->array_size; i++)
 		 // 		param_set(param, i, valuebuf);
 		 // } else {
 		 // 	param_set(param, offset, valuebuf);
 		 // }
- 
+
 		 param_print(param, -1, NULL, 0, 2, 0);
 	 } else {
- 
+
 		 /* Select destination, host overrides parameter node */
 		 int dest = node;
 		 if (server > 0)
@@ -801,7 +812,7 @@
 		 }
 		 param_print(param, -1, NULL, 0, 2, time_now.tv_sec);
 	 }
- 
+
 	 free(offset_array);
 	 optparse_del(parser);
 	 return SLASH_SUCCESS;
@@ -810,69 +821,69 @@
 	 param_completer(slash, token);
  }
  slash_command_completer(set, cmd_set, param_set_cmd_completer, "<param> <value>", "Set");
- 
- 
+
+
  static int cmd_add(struct slash *slash) {
-	 
+
 	 int node = slash_dfl_node;
 	 char * include_mask_str = NULL;
 	 char * exclude_mask_str = NULL;
 	 int force = false;
- 
+
 	 optparse_t * parser = optparse_new("cmd add", "<name>[offset] [value]");
 	 optparse_add_help(parser);
 	 optparse_add_int(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
 	 optparse_add_string(parser, 'm', "imask", "MASK", &include_mask_str, "Include mask (param letters) (used for get with wildcard)");
 	 optparse_add_string(parser, 'e', "emask", "MASK", &exclude_mask_str, "Exclude mask (param letters) (used for get with wildcard)");
 	 optparse_add_set(parser, 'f', "force", true, &force, "force setting readonly params");
- 
+
 	 int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
 	 if (argi < 0) {
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 uint32_t include_mask = 0xFFFFFFFF;
 	 uint32_t exclude_mask = PM_HWREG;
- 
+
 	 if (include_mask_str)
 		 include_mask = param_maskstr_to_mask(include_mask_str);
 	 if (exclude_mask_str)
 		 exclude_mask = param_maskstr_to_mask(exclude_mask_str);
- 
+
 	 /* Check if name is present */
 	 if (++argi >= slash->argc) {
 		 printf("missing parameter name\n");
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 if (param_queue.type == PARAM_QUEUE_TYPE_SET) {
- 
+
 		 char * name = slash->argv[argi];
 		 int offset = -1;
 		 param_t * param = NULL;
 		 param_slash_parse(name, node, &param, &offset);
- 
+
 		 if (param == NULL) {
 			 printf("%s not found\n", name);
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 		 if (param->mask & PM_READONLY && !force) {
 			 printf("--force is required to set a readonly parameter\n");
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
- 
+
 		 /* Check if Value is present */
 		 if (++argi >= slash->argc) {
 			 printf("missing parameter value\n");
 			 optparse_del(parser);
 			 return SLASH_EINVAL;
 		 }
-		 
+
 		 char valuebuf[128] __attribute__((aligned(16))) = { };
 		 if (param_str_to_value(param->type, slash->argv[argi], valuebuf) < 0) {
 			 printf("invalid parameter value\n");
@@ -881,49 +892,49 @@
 		 }
 		 /* clear param timestamp so we dont set timestamp flag when serialized*/
 		 *param->timestamp = 0;
- 
+
 		 if (param_queue_add(&param_queue, param, offset, valuebuf) < 0)
 			 printf("Queue full\n");
- 
+
 	 }
- 
+
 	 if (param_queue.type == PARAM_QUEUE_TYPE_GET) {
- 
+
 		 char * name = slash->argv[argi];
 		 int offset = -1;
 		 param_t * param = NULL;
- 
+
 		 /* Go through the list of parameters */
 		 param_list_iterator i = {};
 		 while ((param = param_list_iterate(&i)) != NULL) {
- 
+
 			 /* Name match (with wildcard) */
 			 if (strmatch(param->name, name, strlen(param->name), strlen(name)) == 0) {
 				 continue;
 			 }
- 
+
 			 /* Node match */
 			 if (*param->node != node) {
 				 continue;
 			 }
- 
+
 			 if (param->mask & exclude_mask) {
 				 continue;
 			 }
- 
+
 			 if ((param->mask & include_mask) == 0) {
 				 continue;
-			 } 
- 
+			 }
+
 			 /* Queue */
 			 if (param_queue_add(&param_queue, param, offset, NULL) < 0)
 				 printf("Queue full\n");
-			 continue;	
-			 
+			 continue;
+
 		 }
- 
+
 	 }
- 
+
 	 param_queue_print(&param_queue);
 	 optparse_del(parser);
 	 return SLASH_SUCCESS;
@@ -932,16 +943,16 @@
 	 param_completer(slash, token);
  }
  slash_command_sub_completer(cmd, add, cmd_add, param_cmd_add_cmd_completer, "<param>[offset] [value]", "Add a new parameter to a command");
- 
- 
+
+
  static int cmd_run(struct slash *slash) {
- 
+
 	 unsigned int timeout = slash_dfl_timeout;
 	 unsigned int server = slash_dfl_node;
 	 unsigned int hwid = 0;
 	 int ack_with_pull = true;
 	 int prio = CSP_PRIO_NORM;
- 
+
 	 optparse_t * parser = optparse_new("run", "");
 	 optparse_add_help(parser);
 	 optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout in milliseconds (default = <env>)");
@@ -949,15 +960,15 @@
 	 optparse_add_unsigned(parser, 'h', "hwid", "NUM", 16, &hwid, "include hardware id filter (default = off)");
 	 optparse_add_set(parser, 'a', "no_ack_push", 0, &ack_with_pull, "Disable ack with param push queue");
 	 optparse_add_int(parser, 'p', "prio", "NUM", 0, &prio, "CSP priority (0 = CRITICAL, 1 = HIGH, 2 = NORM (default), 3 = LOW)");
- 
+
 	 int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
 	 if (argi < 0) {
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 if (param_queue.type == PARAM_QUEUE_TYPE_SET) {
- 
+
 		 csp_timestamp_t time_now;
 		 csp_clock_get_time(&time_now);
 		 if (param_push_queue(&param_queue, prio, 0, server, timeout, hwid, ack_with_pull) < 0) {
@@ -966,9 +977,9 @@
 			 return SLASH_EIO;
 		 }
 		 param_queue_print_params(&param_queue, time_now.tv_sec);
- 
+
 	 }
- 
+
 	 if (param_queue.type == PARAM_QUEUE_TYPE_GET) {
 		 if (param_pull_queue(&param_queue, prio, 1, server, timeout)) {
 			 printf("No response\n");
@@ -976,15 +987,15 @@
 			 return SLASH_EIO;
 		 }
 	 }
- 
- 
+
+
 	 optparse_del(parser);
 	 return SLASH_SUCCESS;
  }
  slash_command_sub(cmd, run, cmd_run, "", NULL);
- 
+
  static int cmd_pull(struct slash *slash) {
- 
+
 	 unsigned int timeout = slash_dfl_timeout;
 	 unsigned int server = slash_dfl_node;
 	 char * include_mask_str = NULL;
@@ -992,7 +1003,7 @@
 	 char * nodes_str = NULL;
 	 int paramver = 2;
 	 int prio = CSP_PRIO_NORM;
- 
+
 	 optparse_t * parser = optparse_new("pull", "");
 	 optparse_add_help(parser);
 	 optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout in milliseconds (default = <env>)");
@@ -1002,21 +1013,21 @@
 	 optparse_add_string(parser, 'n', "nodes", "NODES", &nodes_str, "Comma separated list of nodes to pull parameters from");
 	 optparse_add_int(parser, 'v', "paramver", "NUM", 0, &paramver, "parameter system version (default = 2)");
 	 optparse_add_int(parser, 'p', "prio", "NUM", 0, &prio, "CSP priority (0 = CRITICAL, 1 = HIGH, 2 = NORM (default), 3 = LOW)");
- 
+
 	 int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
 	 if (argi < 0) {
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 uint32_t include_mask = 0xFFFFFFFF;
 	 uint32_t exclude_mask = PM_REMOTE | PM_HWREG;
- 
+
 	 if (include_mask_str)
 		 include_mask = param_maskstr_to_mask(include_mask_str);
 	 if (exclude_mask_str)
 		 exclude_mask = param_maskstr_to_mask(exclude_mask_str);
- 
+
 	 int result = SLASH_SUCCESS;
 	 uint8_t num_nodes = 0;
 	 uint16_t *nodes;
@@ -1050,7 +1061,7 @@
 		 }
 		 free(start);
 		 num_nodes = idx;
-	 }	
+	 }
 	 for (uint8_t i = 0; i < num_nodes; i++) {
 		 if (param_pull_all(prio, 1, nodes[i], include_mask, exclude_mask, timeout, paramver)) {
 			 printf("No response from %d\n", nodes[i]);
@@ -1062,28 +1073,28 @@
 	 return result;
  }
  slash_command(pull, cmd_pull, "[OPTIONS]", "Pull all metrics from given CSP node(s)");
- 
+
  static int cmd_new(struct slash *slash) {
- 
+
 	 int paramver = 2;
 	 char *name = NULL;
- 
+
 	 optparse_t * parser = optparse_new("cmd new", "<get/set> <cmd name>");
 	 optparse_add_help(parser);
 	 optparse_add_int(parser, 'v', "paramver", "NUM", 0, &paramver, "parameter system version (default = 2)");
- 
+
 	 int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
 	 if (argi < 0) {
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 if (++argi >= slash->argc) {
 		 printf("Must specify 'get' or 'set'\n");
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 /* Set/get */
 	 if (strncmp(slash->argv[argi], "get", 4) == 0) {
 		 param_queue.type = PARAM_QUEUE_TYPE_GET;
@@ -1094,39 +1105,39 @@
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 if (++argi >= slash->argc) {
 		 printf("Must specify a command name\n");
 		 optparse_del(parser);
 		 return SLASH_EINVAL;
 	 }
- 
+
 	 /* Command name */
 	 name = slash->argv[argi];
 	 strncpy(param_queue.name, name, sizeof(param_queue.name)-1);  // -1 to fit NULL byte
- 
+
 	 csp_timestamp_t time_now;
 	 csp_clock_get_time(&time_now);
 	 param_queue.used = 0;
 	 param_queue.version = paramver;
 	 param_queue.last_timestamp = 0;
 	 param_queue.client_timestamp = time_now.tv_sec;
- 
+
 	 printf("Initialized new command: %s\n", name);
- 
+
 	 optparse_del(parser);
 	 return SLASH_SUCCESS;
  }
  slash_command_sub(cmd, new, cmd_new, "<get/set> <cmd name>", "Create a new command");
- 
- 
+
+
  static int cmd_done(struct slash *slash) {
 	 param_queue.type = PARAM_QUEUE_TYPE_EMPTY;
 	 return SLASH_SUCCESS;
  }
  slash_command_sub(cmd, done, cmd_done, "", "Exit cmd edit mode");
- 
- 
+
+
  static int cmd_print(struct slash *slash) {
 	 if (param_queue.type == PARAM_QUEUE_TYPE_EMPTY) {
 		 printf("No active command\n");
@@ -1137,4 +1148,3 @@
 	 return SLASH_SUCCESS;
  }
  slash_command(cmd, cmd_print, NULL, "Show current command");
- 

--- a/src/resbuf_dump.c
+++ b/src/resbuf_dump.c
@@ -18,8 +18,8 @@
 #include <sys/types.h>
 #include <csp/csp_cmp.h>
 #include <slash/slash.h>
-#include <slash/dflopt.h>
 #include <slash/optparse.h>
+#include <apm/csh_api.h>
 #include <time.h>
 
 

--- a/src/slash_apm.c
+++ b/src/slash_apm.c
@@ -28,7 +28,7 @@ slash_command_group(apm, "apm");
     1 = void libmain(void)
     2 = int libmain(void)
 */
-__attribute__((used)) const int apm_init_version = APM_INIT_VERSION;
+static const int apm_init_version = APM_INIT_VERSION;
 typedef int (*libmain_t)(void);
 typedef void (*libinfo_t)(void);
 
@@ -384,6 +384,8 @@ static int apm_info_cmd(struct slash *slash) {
 	if (!search_str && (++argi < slash->argc)) {
 		search_str = slash->argv[argi];
 	}
+
+    printf("\033[1mCSH host API: \033[32m%d\033[0m\n\n", apm_init_version);
 
     for (apm_entry_t * e = apm_queue; e; e = e->next) {
         if (!search_str || strstr(e->file, search_str)) {

--- a/src/slash_apm.c
+++ b/src/slash_apm.c
@@ -42,7 +42,7 @@ struct apm_entry_s {
     char args[256];
     libmain_t libmain_f;
     libinfo_t libinfo_f;
-
+    int apm_init_version;
     apm_entry_t * next;
 };
 
@@ -101,6 +101,7 @@ apm_entry_t * load_apm(const char * path) {
     /* Get references to APM API functions */
     e->libmain_f = dlsym(handle, "libmain");
     e->libinfo_f = dlsym(handle, "libinfo");
+    e->apm_init_version = *(int *)dlsym(handle, "apm_init_version");
 
     e->handle = handle;
 
@@ -386,7 +387,7 @@ static int apm_info_cmd(struct slash *slash) {
 
     for (apm_entry_t * e = apm_queue; e; e = e->next) {
         if (!search_str || strstr(e->file, search_str)) {
-            printf("  \033[32m%-30s\033[0m %-80s\n", e->file, e->path);
+            printf("  \033[32m%-30s\033[0m %-80s\tCSH API: %d\n", e->file, e->path, e->apm_init_version);
             if (e->libinfo_f) {
                 e->libinfo_f();
             }

--- a/src/slash_apm.c
+++ b/src/slash_apm.c
@@ -2,7 +2,6 @@
 #include "walkdir.h"
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
 #include <param/param.h>
 #include <param/param_list.h>
 #include <dlfcn.h>

--- a/src/slash_csp.c
+++ b/src/slash_csp.c
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 #include "base16.h"
 #include "known_hosts.h"
 

--- a/src/slash_eth.c
+++ b/src/slash_eth.c
@@ -37,7 +37,6 @@
 #include <linux/netdevice.h>
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
 #include "base16.h"
 #include "known_hosts.h"
 

--- a/src/slash_nodes_cmds.c
+++ b/src/slash_nodes_cmds.c
@@ -3,10 +3,6 @@
 #include <slash/slash.h>
 #include <slash/dflopt.h>
 
-
-unsigned int slash_dfl_node = 0;
-unsigned int slash_dfl_timeout = 1000;
-
 static int cmd_node(struct slash *slash) {
 
 	if (slash->argc < 1) {

--- a/src/slash_nodes_cmds.c
+++ b/src/slash_nodes_cmds.c
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <slash/slash.h>
+#include <slash/dflopt.h>
+
+
+unsigned int slash_dfl_node = 0;
+unsigned int slash_dfl_timeout = 1000;
+
+static int cmd_node(struct slash *slash) {
+
+	if (slash->argc < 1) {
+		/* Only print node when explicitly asked,
+			as it should be shown in the prompt.
+			(it may be truncated when the hostname is too long) */
+		printf("Default node = %d\n", slash_dfl_node);
+	}
+
+	if (slash->argc == 2) {
+
+		/* We rely on user to provide known hosts implementation */
+		int known_hosts_get_node(char * find_name);
+		slash_dfl_node = known_hosts_get_node(slash->argv[1]);
+		if (slash_dfl_node == 0)
+			slash_dfl_node = atoi(slash->argv[1]);
+	}
+
+	return SLASH_SUCCESS;
+}
+
+
+/* Temporarily declare host_name_completer prototype here */
+
+extern void host_name_completer(struct slash *slash, char * token);
+
+slash_command_completer(node, cmd_node, host_name_completer, "[node]", "Set global default node");

--- a/src/slash_nodes_cmds.c
+++ b/src/slash_nodes_cmds.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <slash/slash.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 
 static int cmd_node(struct slash *slash) {
 

--- a/src/spaceboot_slash.c
+++ b/src/spaceboot_slash.c
@@ -10,8 +10,8 @@
 #include <signal.h>
 
 #include <slash/slash.h>
-#include <slash/dflopt.h>
 #include <slash/optparse.h>
+#include <apm/csh_api.h>
 #include <param/param.h>
 #include <param/param_list.h>
 #include <param/param_client.h>
@@ -24,6 +24,8 @@
 #include <csp/csp.h>
 #include <csp/csp_cmp.h>
 #include <csp/csp_crc32.h>
+
+#include "csh_internals.h"
 
 static int ping(int node) {
 

--- a/src/stdbuf_client.c
+++ b/src/stdbuf_client.c
@@ -3,7 +3,7 @@
 #include <csp/csp.h>
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 #include <ctype.h>
 #include <time.h>
 #include <unistd.h>

--- a/src/stdbuf_mon.c
+++ b/src/stdbuf_mon.c
@@ -17,8 +17,8 @@
 #include <sys/types.h>
 #include <csp/csp_cmp.h>
 #include <slash/slash.h>
-#include <slash/dflopt.h>
 #include <slash/optparse.h>
+#include <apm/csh_api.h>
 
 
 

--- a/src/vmem_client_slash.c
+++ b/src/vmem_client_slash.c
@@ -22,7 +22,7 @@
 
 #include <slash/slash.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
 
 static int vmem_client_slash_list(struct slash *slash)
 {

--- a/src/vmem_client_slash_ftp.c
+++ b/src/vmem_client_slash_ftp.c
@@ -20,7 +20,8 @@
 #include <slash/slash.h>
 #include <slash/completer.h>
 #include <slash/optparse.h>
-#include <slash/dflopt.h>
+#include <apm/csh_api.h>
+#include "csh_internals.h"
 
 static int vmem_client_slash_download(struct slash *slash)
 {
@@ -382,13 +383,6 @@ static int vmem_client_slash_crc32(struct slash *slash) {
 	return SLASH_SUCCESS;
 }
 slash_command(crc32, vmem_client_slash_crc32, "<address> <length>", "Calculate CRC32 on a VMEM area");
-
-unsigned int rdp_dfl_window = 3;
-unsigned int rdp_dfl_conn_timeout = 10000;
-unsigned int rdp_dfl_packet_timeout = 5000;
-unsigned int rdp_dfl_delayed_acks = 1;
-unsigned int rdp_dfl_ack_timeout = 2000;
-unsigned int rdp_dfl_ack_count = 2;
 
 static int vmem_client_rdp_options(struct slash *slash) {
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,6 @@ test('require_version_tests', require_version_tests)
 set_array_tests = executable(
     'set_array_tests',
     sources: ['param_slash_parse_array_tests.c', '../src/param_slash.c'],
-    dependencies: [csp_dep, slash_dep, param_dep],
+    dependencies: [csp_dep, slash_dep, param_dep, utils_lib_dep],
 )
 test('set_array_tests', set_array_tests)


### PR DESCRIPTION
- Add (header only) dependency to "apm_csh"
- Update source files to include <apm/csh_api.h> instead of <slash/dflopt.h>
- Fix potential memory leaks (or worse...) by checking and handling return value of realloc() and others (thanks Valgrind)
- Update APM loader to allow CSH API 9 to load APM with CSH API 8 (mainly as an example of how to do that, should we need to)
- Update "apm info" to show CSH API version of each APM
- Fix weird indentation in "src/param_slash.c"