### PR TITLE
CSH-21 Rollout of `csh_add_node_option(...)`

### DIFF
--- a/src/hk_param_sniffer.c
+++ b/src/hk_param_sniffer.c
@@ -78,7 +78,7 @@ static int hk_utcparam(struct slash * slash) {
 	unsigned int node = slash_dfl_node;
 	if (semicolon > slash->argv[argi]) {
 		*semicolon = '\0';
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	} else {
 		/* Node is not included, so we fake a semicolon before the string */
 		semicolon = slash->argv[argi] - 1;
@@ -152,7 +152,7 @@ static int hk_timeoffset(struct slash * slash) {
 
 	unsigned int node = slash_dfl_node;
 	optparse_t * parser = optparse_new("hk timeoffset [epoch]", "Satellite epoch time in seconds relative to Jan 1th 1970");
-	optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+	csh_add_node_option(parser, &node);
 	optparse_add_help(parser);
 	int argi = optparse_parse(parser, slash->argc - 1, (const char **)slash->argv + 1);
 	if (argi < 0) {

--- a/src/param_list_slash.c
+++ b/src/param_list_slash.c
@@ -271,7 +271,7 @@ Parameters can be manually added with 'list add'.");
     optparse_del(parser);
     return SLASH_SUCCESS;
 }
-slash_command_sub(list, download, list_download, "[OPTIONS...] [node]", "Download a list of remote parameters");
+slash_command_sub_completer(list, download, list_download, host_name_completer, "[OPTIONS...] [node]", "Download a list of remote parameters");
 
 static int list_forget(struct slash *slash)
 {
@@ -299,7 +299,7 @@ This makes it possible to download them again, in cases where they've changed.")
     optparse_del(parser);
     return SLASH_SUCCESS;
 }
-slash_command_sub(list, forget, list_forget, "[node]", "Forget remote parameters. Omit or set node to -1 to include all.");
+slash_command_sub_completer(list, forget, list_forget, host_name_completer, "[node]", "Forget remote parameters. Omit or set node to -1 to include all.");
 
 
 static int list_add(struct slash *slash)

--- a/src/param_list_slash.c
+++ b/src/param_list_slash.c
@@ -245,7 +245,7 @@ Fetches metadata such as name and type\n\
 Metadata must be known before values can be pulled.\n\
 Parameters can be manually added with 'list add'.");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 3)");
     optparse_add_set(parser, 'r', "remote", 1, &include_remotes, "Include remote params when storing list");
@@ -257,8 +257,7 @@ Parameters can be manually added with 'list add'.");
     }
 
     if (++argi < slash->argc) {
-        printf("Node as argument, is deprecated\n");
-        node = atoi(slash->argv[argi]);
+        get_host_by_addr_or_name(&node, slash->argv[argi]);
     }
 
     if(node == 0){
@@ -292,8 +291,7 @@ This makes it possible to download them again, in cases where they've changed.")
     }
 
     if (++argi < slash->argc) {
-        printf("Node as argument, is deprecated\n");
-        node = atoi(slash->argv[argi]);
+        get_host_by_addr_or_name(&node, slash->argv[argi]);
     }
 
     printf("Removed %i parameters\n", param_list_remove(node, 1));
@@ -316,7 +314,7 @@ static int list_add(struct slash *slash)
 
     optparse_t * parser = optparse_new("list add", "<name> <id> <type>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 'a', "array", "NUM", 0, &array_len, "array length (default = none)");
     optparse_add_int(parser, 'v', "vmem", "NUM", 0, &vmem_type, "VMEM type (default = none)");
     optparse_add_string(parser, 'c', "comment", "STRING", (char **) &helpstr, "help text");

--- a/src/resbuf_dump.c
+++ b/src/resbuf_dump.c
@@ -71,7 +71,7 @@ static int resbuf_dump_slash(struct slash *slash) {
 
     optparse_t * parser = optparse_new("resbuf", "");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
 	optparse_add_string(parser, 'f', "filename", "PATH", &filename, "write to file, or 'timestamp' for timestamped file in cwd");
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);

--- a/src/slash_csp.c
+++ b/src/slash_csp.c
@@ -59,7 +59,7 @@ static int slash_csp_ping(struct slash *slash)
 
     optparse_t * parser = optparse_new("ping", "[node]");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
 	optparse_add_unsigned(parser, 's', "size", "NUM", 0, &size, "size (default = 0)");
 
@@ -70,7 +70,7 @@ static int slash_csp_ping(struct slash *slash)
     }
 
 	if (++argi < slash->argc) {
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	}
 
 	slash_printf(slash, "Ping node %u size %u timeout %u: ", node, size, timeout);
@@ -87,7 +87,7 @@ static int slash_csp_ping(struct slash *slash)
 	return SLASH_SUCCESS;
 }
 
-slash_command(ping, slash_csp_ping, "[node]", "Ping a system");
+slash_command_completer(ping, slash_csp_ping, host_name_completer, "[node]", "Ping a system");
 
 static int slash_csp_reboot(struct slash *slash)
 {
@@ -96,7 +96,7 @@ static int slash_csp_reboot(struct slash *slash)
 
     optparse_t * parser = optparse_new("reboot", "[node]");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
     if (argi < 0) {
@@ -105,7 +105,7 @@ static int slash_csp_reboot(struct slash *slash)
     }
 
    	if (++argi < slash->argc) {
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	}
 
 
@@ -124,7 +124,7 @@ static int slash_csp_shutdown(struct slash *slash)
 
     optparse_t * parser = optparse_new("shutdown", "[node]");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
     if (argi < 0) {
@@ -133,7 +133,7 @@ static int slash_csp_shutdown(struct slash *slash)
     }
 
    	if (++argi < slash->argc) {
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	}
 
 
@@ -153,7 +153,7 @@ static int slash_csp_buffree(struct slash *slash)
 
     optparse_t * parser = optparse_new("buffree", "[node]");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
@@ -163,7 +163,7 @@ static int slash_csp_buffree(struct slash *slash)
     }
 
    	if (++argi < slash->argc) {
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	}
 
 
@@ -183,7 +183,7 @@ static int slash_csp_uptime(struct slash *slash)
 
     optparse_t * parser = optparse_new("uptime", "[node]");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
@@ -193,7 +193,7 @@ static int slash_csp_uptime(struct slash *slash)
     }
 
    	if (++argi < slash->argc) {
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	}
 
 
@@ -214,7 +214,7 @@ static int slash_csp_cmp_ident(struct slash *slash)
 
     optparse_t * parser = optparse_new("ident", "[node]");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
 	optparse_add_set(parser, 'o', "override", true, &override, "Allow overriding hostname for a known node");
 
@@ -225,7 +225,7 @@ static int slash_csp_cmp_ident(struct slash *slash)
     }
 
 	if (++argi < slash->argc) {
-		node = atoi(slash->argv[argi]);
+		get_host_by_addr_or_name(&node, slash->argv[argi]);
 	}
 
 	struct csp_cmp_message msg = {
@@ -269,7 +269,7 @@ static int slash_csp_cmp_ident(struct slash *slash)
 	return SLASH_SUCCESS;
 }
 
-slash_command(ident, slash_csp_cmp_ident, "[node]", "Ident");
+slash_command_completer(ident, slash_csp_cmp_ident, host_name_completer, "[node]", "Ident");
 
 
 static int slash_csp_cmp_ifstat(struct slash *slash)
@@ -280,7 +280,7 @@ static int slash_csp_cmp_ifstat(struct slash *slash)
 
     optparse_t * parser = optparse_new("ifstat", "<ifname>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
 
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
@@ -349,7 +349,7 @@ static int slash_csp_cmp_peek(struct slash *slash)
 
     optparse_t * parser = optparse_new("peek", "<addr> <len>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version, 1=32-bit <addr>, 2=64-bit <addr> (default = 1)");
 
@@ -463,7 +463,7 @@ static int slash_csp_cmp_poke(struct slash *slash)
 
     optparse_t * parser = optparse_new("poke", "<addr> <data base16>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version, 1=32-bit <addr>>, 2=64-bit <addr> (default = 1)");
 

--- a/src/spaceboot_slash.c
+++ b/src/spaceboot_slash.c
@@ -99,7 +99,7 @@ static int slash_csp_switch(struct slash * slash) {
 
     optparse_t * parser = optparse_new("switch", "<slot>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 'c', "count", "NUM", 0, &times, "number of times to boot into this slow (deafult = 1)");
 	optparse_add_unsigned(parser, 'd', "delay", "NUM", 0, &reboot_delay, "Delay to allow module to boot (default = 1000 ms)");
 
@@ -308,7 +308,7 @@ static int slash_csp_program(struct slash * slash) {
 
     optparse_t * parser = optparse_new("program", "<slot>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_string(parser, 'f', "file", "FILENAME", &filename, "File to upload (defaults to AUTO)");
     optparse_add_set(parser, 'F', "force", 1, &force, "Do not ask for confirmation before programming");
     optparse_add_set(parser, 'c', "crc32", 1, &do_crc32, "Compare CRC32 as a program success criteria");
@@ -475,7 +475,7 @@ static int slash_sps(struct slash * slash) {
 
     optparse_t * parser = optparse_new("sps", "<switch-to-slot> <slot-to-program>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
 	optparse_add_unsigned(parser, 'd', "delay", "NUM", 0, &reboot_delay, "Delay to allow module to boot (default = 1000 ms)");
     optparse_add_set(parser, 'c', "crc32", 1, &do_crc32, "Compare CRC32 as a program success criteria");
 

--- a/src/stdbuf_client.c
+++ b/src/stdbuf_client.c
@@ -19,7 +19,7 @@ static int stdbuf2_mon_slash(struct slash *slash) {
 
     optparse_t * parser = optparse_new("stdbuf2", "");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_string(parser, 'f', "log", "STRING", &log_name_tmp, "Log file name");
 

--- a/src/stdbuf_mon.c
+++ b/src/stdbuf_mon.c
@@ -91,7 +91,7 @@ static int stdbuf_mon_slash(struct slash *slash) {
 
     optparse_t * parser = optparse_new("stdbuf2", "");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "paramversion (default = 2)");
 

--- a/src/vmem_client_slash.c
+++ b/src/vmem_client_slash.c
@@ -32,7 +32,7 @@ static int vmem_client_slash_list(struct slash *slash)
 
     optparse_t * parser = optparse_new("vmem", NULL);
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 2)");
     int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);

--- a/src/vmem_client_slash_ftp.c
+++ b/src/vmem_client_slash_ftp.c
@@ -34,7 +34,7 @@ static int vmem_client_slash_download(struct slash *slash)
 
     optparse_t * parser = optparse_new("download", "<address> <length base10 or base16> <file>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 1)");
 	// optparse_add_unsigned(parser, 'o', "offset", "NUM", 0, &offset, "byte offset in file (default = 0)");
@@ -187,7 +187,7 @@ static int vmem_client_slash_upload(struct slash *slash)
 
     optparse_t * parser = optparse_new("upload", "<file> <address>");
     optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    csh_add_node_option(parser, &node);
     optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
     optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 1)");
 	optparse_add_unsigned(parser, 'o', "offset", "NUM", 0, &offset, "byte offset in file (default = 0)");
@@ -277,7 +277,7 @@ static int vmem_client_slash_crc32(struct slash *slash) {
 
 	optparse_t * parser = optparse_new("crc32", "<address> [length base10 or base16]");
 	optparse_add_help(parser);
-	optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+	csh_add_node_option(parser, &node);
 	optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
 	optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 1)");
 	optparse_add_string(parser, 'f', "file", "STR", &file, "file to compare crc32 against, length = file size");


### PR DESCRIPTION
Find/replace `optparse_add_unsigned(parser, 'n', "node", ...)` with `csh_add_node_option(...)`.
Also added `get_host_by_addr_or_name(...)` (and `host_name_completer(...)`) to: `ping`, `ident`, `list download` and `list forget` positional argument (this allows for writing `ping pdu0-a` etc.).
