### PR TITLE
Added functions to register callbacks to the `param_sniffer()`

### DIFF
--- a/src/param_sniffer.h
+++ b/src/param_sniffer.h
@@ -9,9 +9,23 @@
 #define SRC_PARAM_SNIFFER_H_
 
 #include <csp/csp.h>
+#include <param/param.h>
+#include <param/param_queue.h>
 
 int param_sniffer_crc(csp_packet_t * packet);
 int param_sniffer_log(void * ctx, param_queue_t *queue, param_t *param, int offset, void *reader, csp_timestamp_t *timestamp);
 void param_sniffer_init(int add_logfile);
+
+/* TODO Kevin: We should probably pass along `*queue`, `offset` and `*timestamp` as well. */
+typedef void (*param_sniffer_callback_f)(param_t * param, void * context);
+/**
+ * @brief Register a function to be called when a parameter is sniffed and deserialized from the network.
+ * 
+ * @param callback[in]		Callback function to call whenever a decoding error is encountered.
+ * @param context[in] 		User-supplied context for the callback function. Must remain valid for as long as the function is registered (is not copied).
+ * @return int 					0 OK, <0 ERROR
+ */
+int param_sniffer_register_callback(param_sniffer_callback_f callback, void * context);
+int param_sniffer_unregister_callback(param_sniffer_callback_f callback);
 
 #endif /* SRC_PARAM_SNIFFER_H_ */


### PR DESCRIPTION
This is your chance to stop me @troelsjessen! :)

There's still a couple of things I want to change.
But if you have any major grievances with the general concept, you can let me know before I continue.

I've tested it ad-hoc, with the following function/callbacks:
```
void my_sniffer_callback(param_t * param, void *context) {
    printf("AAA %s %s\n", param->name, (char*)context);
}

void my_other_sniffer_callback(param_t * param, void *context) {
    printf("BBB %s%s\n", param->name, (char*)context);
}

void register_callbacks(void) {
    param_sniffer_register_callback(my_sniffer_callback, "hello there");
    param_sniffer_register_callback(my_other_sniffer_callback, ". What is up?");
}

void unregister_callbacks(void) {
    param_sniffer_unregister_callback(my_sniffer_callback);
    param_sniffer_unregister_callback(my_other_sniffer_callback);
}
```

`pull` after calling `register_callbacks()`:
```
BBB csp_buf_out. What is up?
AAA csp_buf_out hello there
BBB csp_conn_out. What is up?
AAA csp_conn_out hello there
BBB csp_conn_ovf. What is up?
AAA csp_conn_ovf hello there
BBB csp_conn_noroute. What is up?
  51:124  csp_buf_out          = AAA csp_conn_noroute hello there
0                   
  52:124  csp_conn_out         = 0                   
BBB csp_inval_reply. What is up?
...
AAA csp_print_rdp hello there
BBB csp_print_packet. What is up?
AAA csp_print_packet hello there
```

Pull after calling `unregister_callbacks()`:
```
  51:124  csp_buf_out          = 0                   
  52:124  csp_conn_out         = 0                   
...
  58:124  csp_print_rdp        = 0                   
  59:124  csp_print_packet     = 0                   
 1001:124  test_array_param     = [0 1 2 3 4 5 6 7]   
 1002:124  test_str             = 
 ```
 
 Valgrind tested, no errors.