### PR TITLE
Allow setting individual parameters that do not have a mask

### DIFF
--- a/src/param_slash.c
+++ b/src/param_slash.c
@@ -537,7 +537,7 @@ static int cmd_get(struct slash *slash) {
 			continue;
 		}
 
-		if (param->mask != 0 && (param->mask & mask) == 0) {
+		if (mask != 0xFFFFFFFF && (param->mask & mask) == 0) {
 			continue;
 		}
 

--- a/src/param_slash.c
+++ b/src/param_slash.c
@@ -537,7 +537,7 @@ static int cmd_get(struct slash *slash) {
 			continue;
 		}
 
-		if ((param->mask & mask) == 0) {
+		if (strchr(name, '*') != NULL && (param->mask & mask) == 0) {
 			continue;
 		}
 

--- a/src/param_slash.c
+++ b/src/param_slash.c
@@ -946,7 +946,7 @@ static int cmd_add(struct slash *slash) {
 				continue;
 			}
 
-			if ((param->mask & include_mask) == 0) {
+			if (include_mask != 0xFFFFFFFF && (param->mask & include_mask) == 0) {
 				continue;
 			}
 

--- a/src/param_slash.c
+++ b/src/param_slash.c
@@ -537,7 +537,7 @@ static int cmd_get(struct slash *slash) {
 			continue;
 		}
 
-		if (strchr(name, '*') != NULL && (param->mask & mask) == 0) {
+		if (param->mask != 0 && (param->mask & mask) == 0) {
 			continue;
 		}
 


### PR DESCRIPTION
If executing
`list add reset 285 u08`
followed by
`set reset 1`
CSH is not transmitting a CSP message

I discovered this while using a parameter protected by PM_HIDDEN, causing it to not being delivered by `list download`