### PR TITLE
fix(hk): skip short packets on source port 13 to avoid a crash

### DIFF
--- a/src/hk_param_sniffer.c
+++ b/src/hk_param_sniffer.c
@@ -212,7 +212,17 @@ bool hk_param_sniffer(csp_packet_t * packet) {
 
 	/* Protocol has a header size of 5, and RDP adds 5 bytes to the end of the packet if activated */
 	size_t header_size = 5;
-	size_t data_len = packet->length - header_size - ((packet->id.flags & CSP_FRDP) ? 5 : 0);
+	size_t overhead = header_size + ((packet->id.flags & CSP_FRDP) ? 5 : 0);
+	/* data_len is unsigned, so subtracting the overhead from a packet that is shorter
+	 * than the overhead does not go negative -- it wraps around to a huge value
+	 * (~SIZE_MAX). The mpack reader below would then read far past the end of the packet
+	 * and crash. This can happen because we handle *any* packet on source port 13, but
+	 * other, shorter traffic uses that port too and carries no param payload. So: if the
+	 * packet is too short to hold a payload, skip it. */
+	if (packet->length < overhead) {
+		return false;
+	}
+	size_t data_len = packet->length - overhead;
 	param_queue_t queue;
 	param_queue_init(&queue, &packet->data[header_size], data_len, data_len, PARAM_QUEUE_TYPE_SET, 2);
 	queue.last_node = packet->id.src;


### PR DESCRIPTION
hk_param_sniffer() handles any packet whose CSP source port is 13, treating it as housekeeping param data. It works out the payload length by subtracting the header/footer overhead from the packet length:

    size_t data_len = packet->length - 5 - ((flags & CSP_FRDP) ? 5 : 0);

data_len is unsigned. Source port 13 is also used by other, shorter traffic (control/ack frames, replies from other services), which carries no param payload. For any such packet shorter than the overhead, the subtraction does not go negative -- it wraps around to a huge value (~SIZE_MAX). The mpack reader is then handed that bogus length and reads far past the end of the packet, segfaulting the sniffer under `prometheus start`.

Fix: check the length first and skip any packet too short to hold a payload.